### PR TITLE
Fix Java system property description

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ In addition to environment variables, other ways of defining configuration also 
 
 - [Java System
   Properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
-  These properties converted to lower case with hyphens and periods replaced by
-  underscores MUST match the environment variables. For example:
+  These properties MUST match the environment variables converting to lower
+  case and replacing underscores with hyphens or periods. For example:
   system property `splunk.context.server-timing.enabled` is equivalent to environment
   variable `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED`.


### PR DESCRIPTION
In Java it actually works the other way than it was described: we convert system property names to environment variable names. Dashes (kebab case) are allowed.
See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1414#issuecomment-733181398