### PR TITLE
Standardize metric signal env var

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ supported including a specific default value.
 | `OTEL_RESOURCE_ATTRIBUTES`             | string  | `unknown_service[:<process>]`    | Yes      | Key/Value resource information. MUST define `service.name`. SHOULD define `deployment.environment`. |
 | `OTEL_TRACES_ENABLED`                  | boolean | `true`                           | No       | Whether instrumentation will create spans to participate in traces or not.                          |
 | `OTEL_TRACES_EXPORTER`                 | string  | `jaeger-thrift-splunk`           | Yes      | Exported data format. MUST support `jaeger-thrift-splunk` and `otlp`.                               |
+| `OTEL_METRICS_ENABLED`                 | boolean | `true`                           | No       | Whether instrumentation will create metric events or not.                                           |
 | `SPLUNK_ACCESS_TOKEN`                  | string  |                                  | No [1]   | Access token added to exported data.                                                                |
 | `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` | boolean | `true`                           | No [2]   | Whether `Server-Timing` header is added to HTTP responses.                                          |
 


### PR DESCRIPTION
This standardizes on the environment variable used to enable/disable the metrics signal if that functionality is provided by a distribution of OTel. It standardizes on `OTEL_METRICS_ENABLED`. It uses the plural to match the [OTel signal name](https://github.com/open-telemetry/opentelemetry-specification/blob/11cc73939a32e3a2e6f11bdeab843c61cf8594e9/specification/glossary.md#signals), and be similar to the existing `OTEL_TRACES_ENABLED`.