### PR TITLE
Guidance on reporting vulnerabilities

### DIFF
--- a/docs/templates/CONTRIBUTING.md
+++ b/docs/templates/CONTRIBUTING.md
@@ -32,7 +32,7 @@ When filing an issue, please do *NOT* include:
 
 ## Reporting Security Issues
 
-See: [SECURITY.md](SECURITY.md#reporting-security-issues)
+See [SECURITY.md](SECURITY.md#reporting-security-issues) for detailed instructions.
 
 ## Contributing via Pull Requests
 


### PR DESCRIPTION
## Why

I feel it is good to add guidance on how vulnerabilities should be reported in `CONTRIBTING.md`. Even for the cost of redundancy.

## What

Copy-paste how to report vulnerabilities from `SECURITY.md` to `CONTRIBTING.md`.