### PR TITLE
Strengthen rules for GitHub Releases

### DIFF
--- a/docs/repository.md
+++ b/docs/repository.md
@@ -78,8 +78,8 @@ Note: the **upstream** project signal you depend on (if any) MUST be stable
 
 ## GitHub Releases
 
-- SHOULD have a signature or a checksum available for all binary release artifacts
-- SHOULD use [signed tags](https://docs.github.com/en/github/authenticating-to-github/signing-tags)
+- MUST have a signature or a checksum available for all binary release artifacts
+- MUST use [signed tags](https://docs.github.com/en/github/authenticating-to-github/signing-tags)
 
 ## Collector
 


### PR DESCRIPTION
## Why

It would be good to give the customers some additional means to perform integrity checks if they need/want.

## What

Require signatures/checksums.

## Side Comments

https://github.com/signalfx/splunk-otel-collector is already adding a checksum in its releases.

It occurs that https://github.com/signalfx/splunk-otel-java does not have any signature and does not publish any checksum.

Are there any others that would have to implement it?

For sure https://github.com/signalfx/splunk-otel-donet would have to but it is not near GA...