### PR TITLE
Tighten requirements around artifact signatures

### DIFF
--- a/docs/repository.md
+++ b/docs/repository.md
@@ -87,7 +87,8 @@ Note: the **upstream** project signal you depend on (if any) MUST be stable
 
 ## GitHub Releases
 
-- MUST have a signature or a checksum available for all binary release artifacts
+- MUST have a signature or a checksum with signature for all release artifacts
+  - SHOULD use Splunk signing key
 - MUST use [signed tags](https://docs.github.com/en/github/authenticating-to-github/signing-tags)
 
 ## Collector


### PR DESCRIPTION
* All assets should be directly or indirectly verifiable so if there are
  checksums they must be signed.
* Add that Splunk signing service should be used