### PR TITLE
Add gdi-admins team

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -20,7 +20,7 @@ approval is granted, GDI projects MUST NOT cut a GA release.
 
 - MUST grant `Admin` [permission
   level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)
-  to `gdi-admins` team
+  to admins team
 - MUST grant `Maintain` [permission
   level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)
   to maintainers team


### PR DESCRIPTION
## Why

Because we no longer allow direct pushes to `main` branch, maintainers should rarely need anything allowed only for `Admin`. `Admin` has a lot of "destructive" privileges.

References: 
- https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization
- https://github.com/signalfx/gdi-specification/pull/72#discussion_r626132786

## What

- Mention `gdi-admins` team which should have e.g. only 3 people like @flands , @owais , @iNikem to reduce the attack surface and increase time coverage at the same time.
- Reduce the `maintainers` team permission level to `Maintain`