### PR TITLE
Require distributions to log warnings when "service.name" is not set up

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -95,7 +95,14 @@ beyond the OpenTelemetry specification exist.
 - `OTEL_RESOURCE_ATTRIBUTES`
   - User MUST define [`service.name`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service)
     resource attribute.
-  - Distribution MUST log a warning when this resource attribute is not set. The warning message MUST clearly describe how to set the attribute or link to relevant documentation.
+  - Distribution MUST log a warning when the `service.name` resource attribute is not set. The
+    warning message MUST clearly describe how to set the attribute or link to relevant documentation.
+    E.g.
+    ```
+    service.name attribute is not set, your service is unnamed and will be difficult to identify.
+    set your service name using the OTEL_RESOURCE_ATTRIBUTES environment variable.
+    E.g. `OTEL_RESOURCE_ATTRIBUTES="service.name=<YOUR_SERVICE_NAME_HERE>"`
+    ```
   - User SHOULD define [`deployment.environment`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/deployment_environment.md#deployment)
     resource attribute.
   - User SHOULD define [`service.version`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service)


### PR DESCRIPTION
GDI spec 1.0 will recommend logging a warning when the `service.name` resource attribute is not set by the user. 

Broader discussion [here](https://github.com/signalfx/gdi-specification/discussions/25)