### PR TITLE
Repository's default permissions of the GITHUB_TOKEN

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -58,6 +58,8 @@ approval is granted, GDI projects MUST NOT cut a GA release.
 - MUST [limit permissions of
   `GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token)
   when used
+  - MUST set [the repository's default permission](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)
+    to just read access for the `contents` scope.
   - MUST only set the absolutely required `permissions` (least privilege)
   - MUST set `permissions` for individual `jobs`
 


### PR DESCRIPTION
## Why

It may be helpful if the default permissions of the GITHUB_TOKEN are not set on the organization level.

## What 

Require setting the repository's default permissions of the GITHUB_TOKEN.

This change only makes sense if it is not already set on the organization level.

It can also help with "controlled" adoption of using only required permissions  of the GITHUB_TOKEN instead of doing a "big bang"