### PR TITLE
Explicitly forbid granting any permissions to individuals

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -30,7 +30,7 @@ approval is granted, GDI projects MUST NOT cut a GA release.
 - MUST NOT grant `Write`, `Maintain`, `Admin` [permission
   level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)
   to any other user nor team
-- MUST NOT grant any permission (including read-only) to any individual
+- MUST NOT grant any permission (including `Read`) to any individual
 
 ### Branch protection
 


### PR DESCRIPTION
According to GDI security guidelines.