### PR TITLE
Change lychee-push GitHub workflow triggers

### DIFF
--- a/.github/workflows/lychee-push.yml
+++ b/.github/workflows/lychee-push.yml
@@ -1,4 +1,9 @@
-on: push
+on:
+  push: 
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Currently, the GH workflow is not triggered when a PR is made from a fork. Example: https://github.com/signalfx/gdi-specification/pull/85

## What

Run when:
- pushed/merged to `main`
- PR is created/updated
- someone manually triggers a build: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/