### PR TITLE
Change wording "project" to "repository" where appropriate

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for this repository
 title: ''
 labels: feature
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/ga_request.md
+++ b/.github/ISSUE_TEMPLATE/ga_request.md
@@ -1,22 +1,22 @@
 ---
-name: Project GA request
-about: Request that a GDI project move to GA
+name: Repository GA request
+about: Request that a GDI repository move to GA
 title: ''
 labels: approval
 assignees: ''
 
 ---
 
-**Which GDI project do you wish to GA?**
+**Which GDI repository do you wish to GA?**
 Name and link to repository
 
 **Does the repository follow the latest tagged minor release in GDI specification?**
 yes/no; if no then please complete before submission
 
-**How long has the GDI project been public?**
+**How long has the GDI repository been public?**
 Approximate amount of time
 
-**Is the project known to be used today?**
+**Is the repository known to be used today?**
 yes/no
 
 **Is there a date by which this approval is needed?**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Release](https://img.shields.io/github/v/tag/signalfx/gdi-specification?include_prereleases&style=for-the-badge)
 
 The GDI specification describes cross-repository requirements and
-expectations. It is applicable to GDI projects.
+expectations. It is applicable to GDI repositories.
 
 > Anything OpenTelemetry or anything that should be in OpenTelemetry will be
 > handled upstream. For information on OpenTelemetry, see the [OpenTelemetry
@@ -16,26 +16,25 @@ The following specification sections are currently in scope:
 - [Repository](specification/repository.md)
 - [Versioning](specification/versioning.md)
 
-GDI projects MUST adopt GDI specification changes by their next `MINOR` release
+GDI repositories MUST adopt GDI specification changes by their next `MINOR` release
 and within three months (whichever is sooner). The GDI specification and GDI
-projects MUST remove any deprecated specification at the next `MAJOR` release.
+repositories MUST remove any deprecated specification at the next `MAJOR` release.
 
-The GDI specification is meant for GDI projects and MUST NOT be required
-reading by GDI project consumers.
+The GDI specification is meant for GDI repositories and MUST NOT be required
+reading by GDI repository consumers.
 
 ## Terms
 
-- Component: Specific feature-set of a GDI project.
+- Component: Specific feature-set of a GDI repository.
 - Data Collector: A way to collect telemetry data within an environment.
-  Refers to `splunk-otel-collector` project.
+  Refers to `splunk-otel-collector` repository.
 - GDI: Getting Data In
-- GDI Project: A project in the `signalfx` GitHub that starts with
+- GDI repository: A repository in the `signalfx` GitHub that starts with
   `splunk-otel-\*`
 - Instrumentation Library: A way to emit telemetry data from an application.
-  Refers to `splunk-otel-<language>` projects.
-- Maintainer: Someone responsible for the specification or a project.
-- Specification: A set of requirements for projects.
-- Project: A GitHub repository.
+  Refers to `splunk-otel-<language>` repositories.
+- Maintainer: Someone responsible for the specification or a repository.
+- Specification: A set of requirements for repositories.
 
 ## Notation Conventions and Compliance
 
@@ -58,7 +57,7 @@ in the GDI specification.
 
 Changes to the GDI specification are versioned according to [Semantic
 Versioning 2.0](https://semver.org/spec/v2.0.0.html) and described in
-[CHANGELOG.md](CHANGELOG.md). Layout changes are not versioned. GDI projects
+[CHANGELOG.md](CHANGELOG.md). Layout changes are not versioned. GDI repositories
 that implement the specification MUST specify which version they implement.
 
 Changes to the change process itself are not currently versioned but may be

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -1,27 +1,27 @@
 # Configuration
 
 One or more configuration variables MAY be needed to properly configure GDI
-projects. Configuration of these variables MUST be supported by environment
-variables and MAY be supported by additional methods. GDI projects MUST adopt
+repositories. Configuration of these variables MUST be supported by environment
+variables and MAY be supported by additional methods. GDI repositories MUST adopt
 stable and SHOULD adopt experimental configuration variables in the
 [OpenTelemetry
 Specification](https://github.com/open-telemetry/opentelemetry-specification)
 before proposing variables to the GDI specification. If a new configuration
-variable is needed by a GDI project it MUST be brought to the GDI specification
+variable is needed by a GDI repository it MUST be brought to the GDI specification
 as a GitHub issue. The GDI specification maintainers SHOULD consider
-introducing needed configuration variables to the OpenTelemetry project before
+introducing needed configuration variables to the OpenTelemetry repository before
 approving Splunk-specific configuration variables.
 
-If a GDI project requires an immediate configuration variable that is not
+If a GDI repository requires an immediate configuration variable that is not
 available in the OpenTelemetry specification and not available in the GDI
-specification, the project MAY introduce a project-specific configuration
+specification, the repository MAY introduce a repository-specific configuration
 variable until the GDI specification maintainers make a decision. Any
-project-specific configuration variable defined SHOULD be prefixed with
+repository-specific configuration variable defined SHOULD be prefixed with
 `SPLUNK_` and MUST NOT be marked as stable unless added to the GDI
-specification. Upon resolution by the GDI specification, the GDI project MUST
-change the project-specific configuration variable by the project's next minor
+specification. Upon resolution by the GDI specification, the GDI repository MUST
+change the repository-specific configuration variable by the repository's next minor
 release. This change MAY result in a breaking change so caution should be
-exhibited when considering project-specific configuration variables.
+exhibited when considering repository-specific configuration variables.
 
 Splunk-specific configuration variables defined in the GDI specification MUST
 be prefixed with `SPLUNK_`. If a Splunk-specific configuration variable is
@@ -34,15 +34,15 @@ specification MAY require specific OpenTelemetry configuration variables be
 supported. If it does, the GDI specification MAY require certain values be
 supported including a specific default value.
 
-Whenever a configuration variable changes its name, a stable GDI project
+Whenever a configuration variable changes its name, a stable GDI repository
 (version >= 1.0) MUST support both old and new names until the next major
 release is done. The old configuration variable MUST NOT be removed in a minor
-release. GDI projects that are not yet stable (version < 1.0) SHOULD follow
+release. GDI repositories that are not yet stable (version < 1.0) SHOULD follow
 this rule, but they are not required to. When it is detected that a user uses
 the old configuration variable a warning SHOULD be logged: the warning SHOULD
 state that the old variable is deprecated, the new one should be used instead,
 and that the old one will be removed in the next major release (not stable GDI
-projects MAY remove deprecated features in any future release).
+repositories MAY remove deprecated features in any future release).
 
 Installation and configuration MUST optimize for customer experience and
 time-to-value. Installation and configuration MAY provide a mechanism for

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -1,9 +1,9 @@
 # Repository
 
-Every GDI project repository MUST adhere to the following specification before
-it can release a GA (`1.0.0`) release. GDI projects MUST submit a GitHub issue
-on the GDI specification using the `Project GA approval` type. Until the
-approval is granted, GDI projects MUST NOT cut a GA release.
+Every GDI repository MUST adhere to the following specification before
+it can release a GA (`1.0.0`) release. GDI repositories MUST submit a GitHub issue
+on the GDI specification using the `Repository GA approval` type. Until the
+approval is granted, GDI repositories MUST NOT cut a GA release.
 
 ## Required Configuration
 
@@ -85,11 +85,11 @@ approval is granted, GDI projects MUST NOT cut a GA release.
     - `Breaking Changes` - Any changes that will break backward compatibility
       with previous versions. MUST list all breaking changes.
     - `Bugfixes` - Details of bugs that were fixed. SHOULD list all bug fixes.
-    - `Enhancements` - New features that have been added to the project. SHOULD
+    - `Enhancements` - New features that have been added to the repository. SHOULD
       list all new features.
   - The CHANGELOG.md SHOULD NOT list every PR, but only changes significant
     from an end-user point of view. Anyone who is interested in all the details
-    of every change in the project can use the git log for that.
+    of every change in the repository can use the git log for that.
 - MUST add [CODE_OF_CONDUCT.md](templates/CODE_OF_CONDUCT.md)
 - MUST add [CONTRIBUTING.md](templates/CONTRIBUTING.md)
 - MUST have a [.github/CODEOWNERS](templates/.github/CODEOWNERS) file with a maintainers team
@@ -107,7 +107,7 @@ approval is granted, GDI projects MUST NOT cut a GA release.
   - MUST have troubleshooting information in `README.md`
   - MUST have license information in `README.md`
 - MAY have a `RELEASING.md` file that documents the release process, but this
-  file MUST NOT document private processes. For projects that use private release
+  file MUST NOT document private processes. For repositories that use private release
   jobs, the `RELEASING.md` file SHOULD be absent or, if included, just contain the following note:
   > The release process involves signing built packages and binaries and thus
   > must be kept private and not exposed publicly.

--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-All notable changes to this project are documented in this file.
+All notable changes to this repository are documented in this file.
 
 The format is based on the [Splunk GDI specification](https://github.com/signalfx/gdi-specification/blob/f70eda04ec15685f892edc4b8f05bed557d20206/docs/repository.md#required-files),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### General
 
-- This release marks the first release of the project.
+- This release marks the first release of the repository.
 
 ### Functional Section 1
 

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project! Whether it's a bug
+Thank you for your interest in contributing to our repository! Whether it's a bug
 report, new feature, question, or additional documentation, we greatly value
 feedback and contributions from our community. Read through this document
 before submitting any issues or pull requests to ensure we have all the
@@ -66,13 +66,13 @@ request](https://help.github.com/articles/creating-a-pull-request/).
 ## Finding contributions to work on
 
 Looking at the existing issues is a great way to find something to contribute
-on. As our projects, by default, use the default GitHub issue labels
+on. As our repositories, by default, use the default GitHub issue labels
 (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at
 any 'help wanted' issues is a great place to start.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to
+See the [LICENSE](LICENSE) file for our repository's licensing. We will ask you to
 confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -1,10 +1,10 @@
 # Versioning
 
-All GDI projects MUST be versioned according to [Semantic Versioning
-2.0](https://semver.org/spec/v2.0.0.html). GDI projects are versioned
-separately from OpenTelemetry projects as Splunk-specific breaking changes
-MAY be introduced. GDI projects MUST indicate what version of OpenTelemetry
-projects they are based on through release notes and SHOULD indicate through
+All GDI repositories MUST be versioned according to [Semantic Versioning
+2.0](https://semver.org/spec/v2.0.0.html). GDI repositories are versioned
+separately from OpenTelemetry repositories as Splunk-specific breaking changes
+MAY be introduced. GDI repositories MUST indicate what version of OpenTelemetry
+repositories they are based on through release notes and SHOULD indicate through
 logging. Additional version number constraints can be found in the sections
 below.
 
@@ -21,29 +21,29 @@ feature-complete. In some cases, the experiment MAY be discarded and removed
 entirely. Long-term dependencies SHOULD NOT be taken against experimental
 sections.
 
-GDI projects MAY consist of one or more components. GDI projects MUST be
+GDI repositories MAY consist of one or more components. GDI repositories MUST be
 designed in a manner that allows experimental components to be created without
-breaking the stability guarantees of existing components. GDI projects MUST NOT
+breaking the stability guarantees of existing components. GDI repositories MUST NOT
 be designed in a manner that breaks existing users when a new component beyond
-the project's first component transitions from experimental to stable. This
+the repository's first component transitions from experimental to stable. This
 would punish users of the release candidate component, and hinder adoption.
 
 Terms which denote stability, such as `experimental` MUST NOT be used as part
 of a directory or import name. Package version numbers MAY include a suffix,
 such as `-alpha`, `-beta`, `-rc`, or `-experimental`, to differentiate stable
-and experimental projects.
+and experimental repositories.
 
-GDI project components SHOULD start as experimental. All non-OpenTelemetry
+GDI repository components SHOULD start as experimental. All non-OpenTelemetry
 experimental components MUST be disabled by default, MUST require a
 configuration variable to enable, and MUST clearly be marked as experimental.
 
 ## Stable
 
-The initial stable release version number for GDI projects MUST be `1.0.0` and
+The initial stable release version number for GDI repositories MUST be `1.0.0` and
 follow Semantic Versioning 2.0 for all subsequent releases. Once an
 experimental component has gone through rigorous beta testing, it MAY
 transition to stable. Long-term dependencies MAY now be taken against this
-component. When a new stable component is introduced to a GDI project with an
+component. When a new stable component is introduced to a GDI repository with an
 existing stable release, the `MINOR` version number MUST be incremented and the
 component MUST clearly be marked as stable.
 


### PR DESCRIPTION
Solves https://github.com/signalfx/gdi-specification/issues/100

## Why 

1. There is something like GitHub Project which is something else than a GitHub Repository
1. A common definition for the project is "a temporary endeavor undertaken to create a unique result"

## What

Use the term `repository` instead of `project` in most places.