### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 1.0.0 - 2021-06-01
+
+### General
+
+- First stable release of the GDI specification. This release includes stable
+  requirements and recommendations for GDI repository composition and
+  versioning and Splunk distributions of OpenTelemetry configuration.
+
 ## 1.0.0-rc.3 - 2021-05-25
 
 ### General

--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this repository are documented in this file.
 
-The format is based on the [Splunk GDI specification](https://github.com/signalfx/gdi-specification/blob/f70eda04ec15685f892edc4b8f05bed557d20206/docs/repository.md#required-files),
+The format is based on the [Splunk GDI specification](https://github.com/signalfx/gdi-specification/blob/v1.0.0/specification/repository.md),
 and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased


### PR DESCRIPTION
### General

- First stable release of the GDI specification. This release includes stable requirements and recommendations for GDI repository composition and versioning and Splunk distributions of OpenTelemetry configuration.