### PR TITLE
Change verbiage and link around CLA

### DIFF
--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -75,6 +75,5 @@ any 'help wanted' issues is a great place to start.
 See the [LICENSE](LICENSE) file for our repository's licensing. We will ask you to
 confirm the licensing of your contribution.
 
-We may ask you to sign a [Contributor License Agreement
-(CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger
-changes.
+All contributors must execute the [Splunk Contributor License Agreement
+(CLA) form](https://www.splunk.com/en_us/form/contributions.html).


### PR DESCRIPTION
Per legal review, the verbiage and link about the CLA should be changed.  Happy to discuss in company Slack/email if more details needed.