### PR TITLE
Update CODEOWNERS to add docs team as reviewers for docs changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,14 @@
 * @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers
 
 .github/CODEOWNERS @signalfx/gdi-specification-maintainers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/docs
+*.rst @signalfx/docs
+docs/ @signalfx/docs
+README @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers


### PR DESCRIPTION
As discussed in Slack, this PR aims at standardizing docs team as reviewers for all changes concerning documentation in our repos.