### PR TITLE
Update CODEOWNERS to add docs team as reviewers for docs changes

### DIFF
--- a/specification/templates/.github/CODEOWNERS
+++ b/specification/templates/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 *.md @signalfx/docs
 *.rst @signalfx/docs
 docs/ @signalfx/docs
-README @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers
+README* @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers

--- a/specification/templates/.github/CODEOWNERS
+++ b/specification/templates/.github/CODEOWNERS
@@ -4,3 +4,14 @@
 * @signalfx/gdi-TEAM-maintainers @signalfx/gdi-TEAM-approvers
 
 .github/CODEOWNERS @signalfx/gdi-TEAM-maintainers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/docs
+*.rst @signalfx/docs
+docs/ @signalfx/docs
+README @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers


### PR DESCRIPTION
As discussed in Slack, this PR aims at standardizing docs team as reviewers for all changes concerning documentation in our repos.