### PR TITLE
Remove lines on what configuration a user should provide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Configuration
+
+- Remove suggestion for end users of instrumentation libraries to provide
+  configuration.
+
 ## 1.0.0 - 2021-06-01
 
 ### General

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -121,9 +121,6 @@ beyond the OpenTelemetry specification exist.
     set your service name using the OTEL_RESOURCE_ATTRIBUTES environment variable.
     E.g. `OTEL_RESOURCE_ATTRIBUTES="service.name=<YOUR_SERVICE_NAME_HERE>"`
     ```
-  - User SHOULD define [`deployment.environment`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/deployment_environment.md#deployment)
-    resource attribute.
-  - User SHOULD define [`service.version`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service)
 - `OTEL_PROPAGATORS`
   - Distribution MUST default to `"tracecontext,baggage"`
   - Distribution MUST support and document how to switch to `b3multi`


### PR DESCRIPTION
These lines are empty of meaning as this specification is not intending users to be the audience. Furthermore, there is no specified action to take for the instrumentation authors if values are not provided.