### PR TITLE
Introduce docs section to CONTRIBUTING.md

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -107,6 +107,7 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
   - SHOULD have badges on the `README.md` for other relevant things including artifacts
   - MUST have getting started information in `README.md`
   - MUST have troubleshooting information in `README.md`
+  - MUST link to official Splunk docs if they exist
   - MUST have license information in `README.md`
 - MAY have a `RELEASING.md` file that documents the release process, but this
   file MUST NOT document private processes. For repositories that use private release

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -107,7 +107,7 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
   - SHOULD have badges on the `README.md` for other relevant things including artifacts
   - MUST have getting started information in `README.md`
   - MUST have troubleshooting information in `README.md`
-  - MUST link to official Splunk docs if they exist
+  - MUST link to official Splunk docs in `README.md`
   - MUST have license information in `README.md`
 - MAY have a `RELEASING.md` file that documents the release process, but this
   file MUST NOT document private processes. For repositories that use private release

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -1,23 +1,20 @@
 # Contributing Guidelines
 
 Thank you for your interest in contributing to our repository! Whether it's a bug
-report, new feature, question, or additional documentation, we greatly value
-feedback and contributions from our community. Read through this document
-before submitting any issues or pull requests to ensure we have all the
-necessary information to effectively respond to your bug report or
-contribution.
+report, new feature, or question, we greatly value feedback and contributions from
+our community. Read through this document before submitting any issues or pull 
+requests to ensure we have all the necessary information to effectively respond
+to your bug report or contribution.
 
-In addition to this document, please review our [Code of
-Conduct](CODE_OF_CONDUCT.md). For any code of conduct questions or comments
-please email oss@splunk.com.
+In addition to this document, review our [Code of Conduct](CODE_OF_CONDUCT.md). 
+For any code of conduct questions or comments, send an email to oss@splunk.com.
 
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest
-features. When filing an issue, please check existing open, or recently closed,
-issues to make sure somebody else hasn't already reported the issue. Please try
-to include as much information as you can. Details like these are incredibly
-useful:
+features. When filing an issue, check existing open, or recently closed,
+issues to make sure somebody else hasn't already reported the issue. Try
+to include as much information as you can. Details like these can be useful:
 
 - A reproducible test case or series of steps
 - The version of our code being used
@@ -25,19 +22,28 @@ useful:
 - Anything unusual about your environment or deployment
 - Any known workarounds
 
-When filing an issue, please do *NOT* include:
+When filing an issue, do *NOT* include:
 
-- Internal identifiers such as JIRA tickets
+- Internal identifiers such as Jira tickets
 - Any sensitive information related to your environment, users, etc.
 
 ## Reporting Security Issues
 
-See [SECURITY.md](SECURITY.md#reporting-security-issues) for detailed instructions.
+See [SECURITY.md](SECURITY.md#reporting-security-issues) for instructions.
+
+## Documentation
+
+The documentation of Splunk Observability is open source and is maintained
+in the `signalfx/product-docs` repository, which contains all the prescriptive
+guidance for Splunk Observability products. Prescriptive guidance consists of 
+step-by-step instructions, conceptual material, and decision support for customers.
+
+To contribute to Splunk Observability docs, go to the [product-docs repo](https://github.com/signalfx/product-docs).
 
 ## Contributing via Pull Requests
 
 Contributions via Pull Requests (PRs) are much appreciated. Before sending us a
-pull request, please ensure that:
+pull request, make sure that:
 
 1. You are working against the latest source on the `main` branch.
 2. You check existing open, and recently merged, pull requests to make sure
@@ -47,10 +53,10 @@ pull request, please ensure that:
 4. You submit PRs that are easy to review and ideally less 500 lines of code.
    Multiple PRs can be submitted for larger contributions.
 
-To send us a pull request, please:
+To send us a pull request:
 
 1. Fork the repository.
-2. Modify the source; please ensure a single change per PR. If you also
+2. Modify the source; a single change per PR is recommended. If you also
    reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass and add new tests related to the contribution.
 4. Commit to your fork using clear commit messages.

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -33,12 +33,14 @@ See [SECURITY.md](SECURITY.md#reporting-security-issues) for instructions.
 
 ## Documentation
 
-The documentation of Splunk Observability is maintained in a private repository,
+The Splunk Observability documentation is hosted on https://docs.splunk.com/Observability,
 which contains all the prescriptive guidance for Splunk Observability products. 
 Prescriptive guidance consists of step-by-step instructions, conceptual material,
-and decision support for customers.
+and decision support for customers. Reference documentation and development 
+documentation is hosted on this repository.
 
-To contribute to Splunk Observability docs, contact the Splunk Observability docs team.
+You can send feedback about Splunk Observability docs by clicking the Feedback 
+button on any of our documentation pages.
 
 ## Contributing via Pull Requests
 

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -80,7 +80,7 @@ any 'help wanted' issues is a great place to start.
 
 ## Licensing
 
-See the LICENSE file for our repository's licensing. We will ask you to
+See the [LICENSE](LICENSE) file for our repository's licensing. We will ask you to
 confirm the licensing of your contribution.
 
 ### Contributor License Agreement

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -80,7 +80,7 @@ any 'help wanted' issues is a great place to start.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our repository's licensing. We will ask you to
+See the LICENSE file for our repository's licensing. We will ask you to
 confirm the licensing of your contribution.
 
 ### Contributor License Agreement

--- a/specification/templates/CONTRIBUTING.md
+++ b/specification/templates/CONTRIBUTING.md
@@ -33,12 +33,12 @@ See [SECURITY.md](SECURITY.md#reporting-security-issues) for instructions.
 
 ## Documentation
 
-The documentation of Splunk Observability is open source and is maintained
-in the `signalfx/product-docs` repository, which contains all the prescriptive
-guidance for Splunk Observability products. Prescriptive guidance consists of 
-step-by-step instructions, conceptual material, and decision support for customers.
+The documentation of Splunk Observability is maintained in a private repository,
+which contains all the prescriptive guidance for Splunk Observability products. 
+Prescriptive guidance consists of step-by-step instructions, conceptual material,
+and decision support for customers.
 
-To contribute to Splunk Observability docs, go to the [product-docs repo](https://github.com/signalfx/product-docs).
+To contribute to Splunk Observability docs, contact the Splunk Observability docs team.
 
 ## Contributing via Pull Requests
 


### PR DESCRIPTION
This PR adds a note to our `CONTRIBUTING.md` template to clarify that prescriptive guidance is hosted on https://docs.splunk.com/Observability and how can contributors send feedback about it.