### PR TITLE
Max attr length fix

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -127,7 +127,7 @@ beyond the OpenTelemetry specification exist.
   - Distribution MUST support and document how to switch to `b3multi`
 - Span Collection Limits
   - Distribution MUST default to `1000` for `OTEL_SPAN_LINK_COUNT_LIMIT` (not OpenTelemetry default)
-  - Distribution MUST default to `1200` for `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` (not OpenTelemetry default)
+  - Distribution MUST default to `12000` for `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` (not OpenTelemetry default)
   - Distribution MUST be unset `""` (unlimited) for all others (not OpenTelemetry default)
 - Zipkin exporter
   - Distribution MUST NOT list Zipkin exporter as supported (not supported by Smart Agent)


### PR DESCRIPTION
While majority of the SignalFx tracing libraries set this limit to `1200`, it turns out the actual intended value was `12000` as done by SignalFx Java. 