### PR TITLE
Update Kubernetes Configuration for Splunk Platform

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -137,7 +137,7 @@ In addition, at least one of the below configuration groups,
   - `token` ()                 : [REQUIRED] Token added to exported data.
   - `endpoint` ()              : [REQUIRED] Where to send exported data.
   - `logsEnabled` (`true`)     : Whether logs are collected and sent.
-  - `metricsEnabled` (`true`)  : Whether metrics are collected, received, and sent.
+  - `metricsEnabled` (`false`) : Whether metrics are collected, received, and sent.
 
 Finally, the below Kubernetes secret configuration options MUST be
 supported:


### PR DESCRIPTION
`splunkPlatform.metricsEnabled` is `false` by default because there is no default metrics type index unless user creates it. User need to specify `splunkPlatform.metricsIndex` after creating the index.