### PR TITLE
Fix Java System properties example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.2.1] - 2021-11-29
+
+### General
+
+#### Bug fixes
+
+- Replaced the example for Java system properties in `specification/configuration.md`.
+
 ## [1.2.0] - 2021-11-15
 
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## [1.2.1] - 2021-11-29
-
 ### General
 
 #### Bug fixes

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -212,7 +212,7 @@ In addition to environment variables, other ways of defining configuration also 
   Properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
   These properties MUST match the environment variables converting to lower
   case and replacing underscores with hyphens or periods. For example:
-  system property `splunk.trace.response.header.enabled` is equivalent to environment
+  system property `splunk.trace-response-header.enabled` is equivalent to environment
   variable `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED`.
 
 ### Real User Monitoring Libraries

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -212,8 +212,8 @@ In addition to environment variables, other ways of defining configuration also 
   Properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
   These properties MUST match the environment variables converting to lower
   case and replacing underscores with hyphens or periods. For example:
-  system property `splunk.context.server-timing.enabled` is equivalent to environment
-  variable `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED`.
+  system property `splunk.trace.response.header.enabled` is equivalent to environment
+  variable `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED`.
 
 ### Real User Monitoring Libraries
 


### PR DESCRIPTION
Changed the example for Java properties to env vars (it referred to a deprecated varname).