### PR TITLE
Remove Name from the required profiling LogRecord fields

### DIFF
--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -111,8 +111,6 @@ instances. For each `LogRecord` instance:
 
 ### `LogRecord` Message Fields
 
-- [Name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-name)
-  MUST be set to the constant value `otel.profiling`.
 - [Time](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-timestamp)
   MUST be set to the time that the call stack was sampled.
 - [TraceId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-traceid)


### PR DESCRIPTION
`name` field was removed from log data model, see https://github.com/open-telemetry/opentelemetry-specification/pull/2271