### PR TITLE
profiling: pprof profile.proto format

### DIFF
--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -204,6 +204,6 @@ For each `allocation` sample:
 
 For each `cpu` sample:
 - label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
-- label `thread.status` of type `string` OPTIONALLY can be set to describe the state of the thread
+- label `thread.state` of type `string` OPTIONALLY can be set to describe the state of the thread
 
 Missing file name and function MUST be reported as `unknown`. Missing line number MUST be reported as `-1`.

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -186,7 +186,8 @@ after the `lineno`, separated by a space.
 
 #### PPROF Profile.proto Data Format
 
-`Profile.proto` is a data representation for profiling data defined at https://github.com/google/pprof/tree/master/proto.
+[`Profile.proto`](https://github.com/google/pprof/tree/master/proto) is a data representation for profiling data. It is
+independent of the type of data being collected and the sampling process used to collect that data.
 Log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
 contains either `allocation` or `cpu` samples determined by the data type specified for the log record.
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -190,21 +190,23 @@ after the `lineno`, separated by a space.
 independent of the type of data being collected and the sampling process used to collect that data.
 The log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
 contains either `allocation` or `cpu` samples determined by the data type specified for the log record.
+Data types `int64` and `string` are protocol buffer types, consult
+[protocol buffers documentation](https://developers.google.com/protocol-buffers/docs/proto#scalar).
 
 For each `allocation` and `cpu` sample:
 - label `source.event.name` of type `string` OPTIONALLY can contain the name of the event that triggered the sampling
-- label `source.event.time` of type `long` MUST be set to the time when the sample was taken
+- label `source.event.time` of type `int64` MUST be set to the unix time in millis when the sample was taken
 - label `trace_id` of type `string` MUST be set when sample was taken within a span scope
 - label `span_id` of type `string` MUST be set when sample was taken within a span scope
-- label `thread.id` of type `long` OPTIONALLY can be set to the thread identifier used by the runtime environment
+- label `thread.id` of type `int64` OPTIONALLY can be set to the thread identifier used by the runtime environment
 - label `thread.name` of type `string` OPTIONALLY can be set to the thread name used by runtime environment
-- label `thread.os.id` of type `long` MUST be set to the thread identifier used by the operating system
+- label `thread.os.id` of type `int64` MUST be set to the thread identifier used by the operating system
 
 For each `allocation` sample:
-- value of type `long` must be set to allocation size in bytes
+- value of type `int64` must be set to allocation size in bytes
 
 For each `cpu` sample:
-- label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
+- label `source.event.period` of type `int64` MUST contain the sampling period if this sample represents a periodic event
 - label `thread.state` of type `string` OPTIONALLY can be set to describe the state of the thread
 
 Missing file name and function MUST be reported as `unknown`. Missing line number MUST be reported as `-1`.

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -108,8 +108,8 @@ instances. For each `LogRecord` instance:
 - `source.event.period` MUST contain the sampling period if this `LogRecord` represents a periodic event
 - `source.event.name` OPTIONALLY can contain the name of the event that triggered the sampling
 - `memory.allocated` MUST contain the allocation size if this `LogRecord` represents a memory allocation event
-- `com.splunk.profiling.data.type` MUST be either `allocation` or `cpu`
-- `com.splunk.profiling.data.format` MUST be either `text` or `pprof-gzip-base64`
+- `profiling.data.type` MUST be either `allocation` or `cpu`
+- `profiling.data.format` MUST be either `text` or `pprof-gzip-base64`
 
 ### `LogRecord` Message Fields
 
@@ -188,7 +188,7 @@ after the `lineno`, separated by a space.
 
 [`Profile.proto`](https://github.com/google/pprof/tree/master/proto) is a data representation for profiling data. It is
 independent of the type of data being collected and the sampling process used to collect that data.
-Log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
+The log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
 contains either `allocation` or `cpu` samples determined by the data type specified for the log record.
 
 For each `allocation` and `cpu` sample:
@@ -196,9 +196,9 @@ For each `allocation` and `cpu` sample:
 - label `source.event.time` of type `long` MUST be set to the time when the sample was taken
 - label `trace_id` of type `string` MUST be set when sample was taken within a span scope
 - label `span_id` of type `string` MUST be set when sample was taken within a span scope
-- label `thread.id` of type `long` OPTIONALLY can be set to the thread identifier used by runtime environment
+- label `thread.id` of type `long` OPTIONALLY can be set to the thread identifier used by the runtime environment
 - label `thread.name` of type `string` OPTIONALLY can be set to the thread name used by runtime environment
-- label `thread.native.id` of type `long` MUST be set to the thread identifier used by the operating system
+- label `thread.os.id` of type `long` MUST be set to the thread identifier used by the operating system
 
 For each `allocation` sample:
 - value of type `long` must be set to allocation size in bytes

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -108,6 +108,8 @@ instances. For each `LogRecord` instance:
 - `source.event.period` MUST contain the sampling period if this `LogRecord` represents a periodic event
 - `source.event.name` OPTIONALLY can contain the name of the event that triggered the sampling
 - `memory.allocated` MUST contain the allocation size if this `LogRecord` represents a memory allocation event
+- `com.splunk.profiling.data.type` MUST be either `allocation` or `profiling`
+- `com.splunk.profiling.data.format` MUST be either `text` or `pprof-gzip-base64`
 
 ### `LogRecord` Message Fields
 
@@ -118,9 +120,9 @@ instances. For each `LogRecord` instance:
 - [SpanId](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-spanid)
   MUST be populated when a call stack has been sampled within a span scope.
 - [Body](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body)
-  MUST be populated with the line-terminated call stack (see below)
+  MUST be populated with appropriate payload for specified data type and format.
 
-#### Call Stack Format
+#### Call Stack Format for `text` Data Format
 
 The call stack is a series of lines separated by newlines (`\n`).
 The first line of the call stack is a REQUIRED thread metadata line.
@@ -181,3 +183,27 @@ provides a range of lines, the second `lineno` can be provided after a colon `:`
 - ` <col>` or ` <col>:<col>` - OPTIONAL - If the runtime provides a column or column range, it MAY be provided
 after the `lineno`, separated by a space.
 - literal `)`
+
+#### PPROF Profile.proto Data Format
+
+`Profile.proto` is a data representation for profiling data defined at https://github.com/google/pprof/tree/master/proto.
+Log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
+contains either `allocation` or `profiling` samples determined by the data type specified for the log record.
+
+For each `allocation` and `profiling` sample:
+- label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
+- label `source.event.name` of type `string` OPTIONALLY can contain the name of the event that triggered the sampling
+- label `source.event.time` of type `long` MUST be set to the time when the sample was taken
+- label `trace_id` of type `string` MUST be set when sample was taken within a span scope
+- label `span_id` of type `string` MUST be set when sample was taken within a span scope
+- label `thread.id` of type `long` OPTIONALLY can be set to the thread identifier used by runtime environment
+- label `thread.name` of type `string` OPTIONALLY can be set to the thread name used by runtime environment
+- label `thread.native.id` of type `long` MUST be set to the thread identifier used by the operating system
+
+For each `allocation` sample:
+- value of type `long` must be set to allocation size in bytes
+
+For each `profiling` sample:
+- label `thread.status` of type `string` OPTIONALLY can be set to describe the state of the thread
+
+Missing file name and function MUST be reported as `unknown`. Missing line number MUST be reported as `-1`.

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -108,7 +108,7 @@ instances. For each `LogRecord` instance:
 - `source.event.period` MUST contain the sampling period if this `LogRecord` represents a periodic event
 - `source.event.name` OPTIONALLY can contain the name of the event that triggered the sampling
 - `memory.allocated` MUST contain the allocation size if this `LogRecord` represents a memory allocation event
-- `com.splunk.profiling.data.type` MUST be either `allocation` or `profiling`
+- `com.splunk.profiling.data.type` MUST be either `allocation` or `cpu`
 - `com.splunk.profiling.data.format` MUST be either `text` or `pprof-gzip-base64`
 
 ### `LogRecord` Message Fields
@@ -188,9 +188,9 @@ after the `lineno`, separated by a space.
 
 `Profile.proto` is a data representation for profiling data defined at https://github.com/google/pprof/tree/master/proto.
 Log message will contain a gzip-compressed, base64-encoded protocol buffer conforming to `profile.proto`. Each message
-contains either `allocation` or `profiling` samples determined by the data type specified for the log record.
+contains either `allocation` or `cpu` samples determined by the data type specified for the log record.
 
-For each `allocation` and `profiling` sample:
+For each `allocation` and `cpu` sample:
 - label `source.event.name` of type `string` OPTIONALLY can contain the name of the event that triggered the sampling
 - label `source.event.time` of type `long` MUST be set to the time when the sample was taken
 - label `trace_id` of type `string` MUST be set when sample was taken within a span scope
@@ -202,7 +202,7 @@ For each `allocation` and `profiling` sample:
 For each `allocation` sample:
 - value of type `long` must be set to allocation size in bytes
 
-For each `profiling` sample:
+For each `cpu` sample:
 - label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
 - label `thread.status` of type `string` OPTIONALLY can be set to describe the state of the thread
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -199,8 +199,8 @@ For each `allocation` and `cpu` sample:
 - label `trace_id` of type `string` MUST be set when sample was taken within a span scope
 - label `span_id` of type `string` MUST be set when sample was taken within a span scope
 - label `thread.id` of type `int64` OPTIONALLY can be set to the thread identifier used by the runtime environment
-- label `thread.name` of type `string` OPTIONALLY can be set to the thread name used by runtime environment
-- label `thread.os.id` of type `int64` MUST be set to the thread identifier used by the operating system
+- label `thread.name` of type `string` OPTIONALLY can be set to the thread name used by the runtime environment
+- label `thread.os.id` of type `int64` OPTIONALLY can be set to the thread identifier used by the operating system
 
 For each `allocation` sample:
 - value of type `int64` must be set to allocation size in bytes

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -108,8 +108,8 @@ instances. For each `LogRecord` instance:
 - `source.event.period` MUST contain the sampling period if this `LogRecord` represents a periodic event
 - `source.event.name` OPTIONALLY can contain the name of the event that triggered the sampling
 - `memory.allocated` MUST contain the allocation size if this `LogRecord` represents a memory allocation event
-- `profiling.data.type` MUST be either `allocation` or `cpu`
-- `profiling.data.format` MUST be either `text` or `pprof-gzip-base64`
+- `profiling.data.type` MUST be set to either `allocation` or `cpu`
+- `profiling.data.format` MUST be set to either `text` or `pprof-gzip-base64`
 
 ### `LogRecord` Message Fields
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -191,7 +191,6 @@ Log message will contain a gzip-compressed, base64-encoded protocol buffer confo
 contains either `allocation` or `profiling` samples determined by the data type specified for the log record.
 
 For each `allocation` and `profiling` sample:
-- label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
 - label `source.event.name` of type `string` OPTIONALLY can contain the name of the event that triggered the sampling
 - label `source.event.time` of type `long` MUST be set to the time when the sample was taken
 - label `trace_id` of type `string` MUST be set when sample was taken within a span scope
@@ -204,6 +203,7 @@ For each `allocation` sample:
 - value of type `long` must be set to allocation size in bytes
 
 For each `profiling` sample:
+- label `source.event.period` of type `long` MUST contain the sampling period if this sample represents a periodic event
 - label `thread.status` of type `string` OPTIONALLY can be set to describe the state of the thread
 
 Missing file name and function MUST be reported as `unknown`. Missing line number MUST be reported as `-1`.


### PR DESCRIPTION
Describe sending profiling data in [pprof](https://github.com/google/pprof) [profile.proto](https://github.com/google/pprof/tree/master/proto) format. Pprof payload will contain a batch of samples. Attributes describing an individual sample, that in currently used `text` format are added to `LogRecord`, are added as label to pprof sample.
@vovencij @gsmirnov-splk please review