### PR TITLE
chore: clarify source.event.period unit

### DIFF
--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -107,7 +107,7 @@ Inside each `InstrumentationLibraryLogs` instance is a list of `LogRecord`
 instances. For each `LogRecord` instance:
 
 - `com.splunk.sourcetype` MUST be set to the value `otel.profiling`
-- `source.event.period` MUST contain the sampling period if this `LogRecord` represents a periodic event
+- `source.event.period` MUST contain the sampling period in milliseconds if this `LogRecord` represents a periodic event
 - `source.event.name` OPTIONALLY can contain the name of the event that triggered the sampling
 - `memory.allocated` MUST contain the allocation size if this `LogRecord` represents a memory allocation event
 - `profiling.data.type` MUST be set to either `allocation` or `cpu`
@@ -206,7 +206,7 @@ For each `allocation` sample:
 - value of type `int64` must be set to allocation size in bytes
 
 For each `cpu` sample:
-- label `source.event.period` of type `int64` MUST contain the sampling period if this sample represents a periodic event
+- label `source.event.period` of type `int64` MUST contain the sampling period in milliseconds if this sample represents a periodic event
 - label `thread.state` of type `string` OPTIONALLY can be set to describe the state of the thread
 
 Missing file name and function MUST be reported as `unknown`. Missing line number MUST be reported as `-1`.


### PR DESCRIPTION
The unit for `source.event.period` wasn't specified, however agents send it in milliseconds. But what if we ever want to use sub millisecond intervals? :eyes: 