### PR TITLE
Mark RUM configuration items as stable.

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -235,7 +235,7 @@ In addition to environment variables, other ways of defining configuration also 
 
 ### Real User Monitoring Libraries
 
-**Status**: [Feature-freeze](../README.md#versioning-and-status-of-the-specification)
+**Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
 
 Real User Monitoring (RUM) instrumentation libraries cannot use environment
 variables for configuration. Instead, they MUST expose a `SplunkRum`


### PR DESCRIPTION
The configs have not change in 9 months and we are not aware of any pressing/short-term additions to the core configuration.