### PR TITLE
Revert "MUST NOT use GitHub secrets"

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -52,9 +52,10 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 ### GitHub Actions
 
-- MUST NOT use [GitHub
-  secrets](https://docs.github.com/en/actions/reference/encrypted-secrets)
-  - Exception: Secrets creates by GitHub with `GITHUB_` prefix.
+- MUST use [GitHub
+  secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) to
+  store sensitive data (auth tokens, passwords) and limit their usage to only
+  required places
 - MUST NOT use [Personal Access
   Tokens](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
 - MUST [limit permissions of


### PR DESCRIPTION
Reverts signalfx/gdi-specification#186

This does not look to have had consensus across implementations.

_Based on comment originally posted by @breedx-splk in https://github.com/signalfx/gdi-specification/issues/186#issuecomment-1234431840_