### PR TITLE
Reduce confusion in Span Collection Limits config

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -218,7 +218,7 @@ are required.
 - Span Collection Limits
   - Distribution MUST default to `1000` for `OTEL_SPAN_LINK_COUNT_LIMIT` (not OpenTelemetry default)
   - Distribution MUST default to `12000` for `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` (not OpenTelemetry default)
-  - Distribution MUST be unset `""` (unlimited) for all others (not OpenTelemetry default)
+  - Distribution MUST default to unset (unlimited) for all others (not OpenTelemetry default)
 - Zipkin exporter
   - Distribution MUST NOT list Zipkin exporter as supported (not supported by Smart Agent)
 - `OTEL_TRACES_EXPORTER`


### PR DESCRIPTION
I think the current description is a little confusing.

Also see: https://github.com/signalfx/splunk-otel-ruby/issues/46#issuecomment-1234778117