### PR TITLE
Remove SPLUNK_METRICS_ENDPOINT from Instrumentation Libraries

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -161,7 +161,6 @@ instance using the following environment variables:
 | Name                                   | Default | Description                                                                               |
 |----------------------------------------|---------|-------------------------------------------------------------------------------------------|
 | `SPLUNK_ACCESS_TOKEN`                  |         | Access token added to exported data. [1]                                                  |
-| `SPLUNK_METRICS_ENDPOINT`              |         | Endpoint for metrics data ingest.                                                         |
 | `SPLUNK_PROFILER_CALL_STACK_INTERVAL`  | 10000   | Interval at which call stacks are sampled (in ms) [5]                                     |
 | `SPLUNK_PROFILER_ENABLED`              | false   | Whether CPU profiling is enabled. [2] [5]                                                 |
 | `SPLUNK_PROFILER_LOGS_ENDPOINT`        | *       | Where profiling data is sent. Defaults to the value in `OTLP_EXPORTER_OTLP_ENDPOINT` [5]  |


### PR DESCRIPTION
## Why

Fixes https://github.com/signalfx/gdi-specification/issues/194

The `SPLUNK_METRICS_ENDPOINT` is either not a stable setting or it is not supported in any of the existing instrumentation libraries.

1. In https://github.com/signalfx/splunk-otel-java it is marked as "experimental"
2. In https://github.com/signalfx/splunk-otel-js it looks like a undocumented functionality (so even less than "experimental")
3. https://github.com/signalfx/splunk-otel-go logs that it is not supported if it is set

Initially I wanted to add a "note" that this env var is not required, but a lean towards removing it from the spec. We should use/follow OTel metrics.

Also, during GDI spec review, none of the @signalfx/gdi-specification-maintainers was considering this env var as MUST HAVE.

At last, we do not want to implement it in https://github.com/signalfx/splunk-otel-dotnet

## What 

- In Instrumentation Libraries move `SPLUNK_METRICS_ENDPOINT` from "stable" to "experimental" (and optional) and also introduce other env vars defined here: https://github.com/signalfx/splunk-otel-java/blob/main/docs/advanced-config.md
- Fix issues reported by markdownlint
