### PR TITLE
Update OTLP exporter default requirements

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -222,7 +222,7 @@ are required.
 - Zipkin exporter
   - Distribution MUST NOT list Zipkin exporter as supported (not supported by Smart Agent)
 - `OTEL_TRACES_EXPORTER`
-  - Non-RUM distribution MUST default to `otlp` over gRPC with an endpoint of `localhost:4317`
+  - Non-RUM distribution MUST default to `otlp` using `grpc` or `http/protobuf` transport protocol.
   - Non-RUM distribution MAY offer `jaeger-thrift-splunk` that defaults to `http://127.0.0.1:9080/v1/trace`.
     **NOTE: `jaeger-thrift-splunk` is deprecated.**
     If the user selects `jaeger-thrift-splunk`, distributions MUST log a deprecation warning and suggest an alternate method. For example:


### PR DESCRIPTION
## Why

The OTel specification has been updated some time ago: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specify-protocol

Now, `http/protobuf` is the recommended default transport protocol. 

Also for technical reasons, in .NET our distro, we do not want to default to gRPC protocol. More [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docs/config.md#otlp)

Our backend accepts OTLP over `http/protobuf` on: `https://ingest/.{REALM}.signalfx.com/v2/trace/otlp`

## What

1. Allow defaulting to `http/protobuf`.
2. Remove the default value as this is the same on as [specified in Otel](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md)

This change is backwards compatible.