### PR TITLE
Add a list of GDI repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Release](https://img.shields.io/github/v/tag/signalfx/gdi-specification?include_prereleases&style=for-the-badge)
 
-The GDI specification describes cross-repository requirements and
-expectations. It is applicable to GDI repositories.
+The GDI specification describes cross-repository requirements and expectations.
+It is applicable to GDI repositories listed in [repositories.txt](repositories.txt).
 
 > Anything OpenTelemetry or anything that should be in OpenTelemetry will be
 > handled upstream. For information on OpenTelemetry, see the [OpenTelemetry

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,0 +1,15 @@
+https://github.com/signalfx/splunk-extension-wrapper
+https://github.com/signalfx/splunk-otel-android
+https://github.com/signalfx/splunk-otel-collector
+https://github.com/signalfx/splunk-otel-collector-operator
+https://github.com/signalfx/splunk-otel-cpp
+https://github.com/signalfx/splunk-otel-dotnet
+https://github.com/signalfx/splunk-otel-go
+https://github.com/signalfx/splunk-otel-ios
+https://github.com/signalfx/splunk-otel-ios-crashreporting
+https://github.com/signalfx/splunk-otel-java
+https://github.com/signalfx/splunk-otel-js
+https://github.com/signalfx/splunk-otel-js-web
+https://github.com/signalfx/splunk-otel-lambda
+https://github.com/signalfx/splunk-otel-python
+https://github.com/signalfx/splunk-otel-ruby

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,3 @@
-https://github.com/signalfx/splunk-extension-wrapper
 https://github.com/signalfx/splunk-otel-android
 https://github.com/signalfx/splunk-otel-collector
 https://github.com/signalfx/splunk-otel-collector-operator


### PR DESCRIPTION
## Why

Towards https://github.com/signalfx/gdi-specification/issues/63

## What

Add a list of GDI repositories to be clear for what repositories the spec should be applied. 

It should also facilitate the releasing process. We could create issues in the GDI repos when a new version of the spec is released.