### PR TITLE
Grant Admin role for maintainers team

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -22,9 +22,6 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 - MUST grant `Admin` [permission
   level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)
-  to admins team
-- MUST grant `Maintain` [permission
-  level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)
   to maintainers team
 - MUST grant `Write` [permission
   level](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)


### PR DESCRIPTION
## Why

1. Root cause: https://github.com/signalfx/gdi-specification/pull/192#issuecomment-1324756625
2. Maintainers should be able to configure the repository so that it complies to the GDI spec (e.g. setup branch protection rules)
3. Maintainers  should be able to remove tags and update branch protection rules when necessary
4. There is no definition what an "admin team" is. Currently we have only an admin team for instrumentation repositories.
5. The maintainers is supposed to contain a limited number of contributors 

## What

- Grant `Admin` role for `-maintainers` team
- Remove the line about the "admin team"

