### PR TITLE
Drop Jira app requirement

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -68,7 +68,6 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 ### GitHub Applications
 
-- MUST have Jira GitHub App configured
 - SHOULD have Codecov GitHub App configured
 - SHOULD have Lychee Link Checker GitHub Action configured
 


### PR DESCRIPTION
Introduced in #50 .

I do not see any benefits as we do not use any JIRA-GitHub integration.