### PR TITLE
Updates for repo documentation

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -141,11 +141,13 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 ## Instrumentation Libraries
 
-- MUST document all supported configuration parameters
+- MUST document all configuration parameters that are relevant to Splunk Observability Cloud
+- MUST document all configuration paramenters whose default values deviate significantly from upstream
 - MUST document how to configure manual instrumentation
 - MUST document how to configure log correlation
 - MUST define minimum supported version of each auto-instrumentation framework
   - SHOULD define maximum supported version of each auto-instrumentation framework
+- MAY host the documentation in the Observability Cloud documentation repository
 
 ## Real User Monitoring Libraries
 


### PR DESCRIPTION
Following a conversation with @Kielek, I'd like to modify a bit the language of our specification in regards to required documentation for settings. 

Currently, we're not documenting **all** supported settings. We're documenting what is relevant to our distros in order to send data to o11y, as well as all the settings that are Splunk's.

In the case of specific instrumentations, they're upstream, and work well with defaults, I guess (hope). I'd document their settings only if our defaults deviate significantly or if they must be tweaked to get data right in o11y.

I also added a `MAY` statement so that repo owners have the possibility of editing the documentation in https://github.com/splunk/public-o11y-docs directly instead of adding files in the repos.