### PR TITLE
Relax the meaning of allocation size

### DIFF
--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -226,7 +226,7 @@ For each `allocation` and `cpu` sample:
 
 For each `allocation` sample:
 
-- value of type `int64` must be set to allocation size in bytes
+- value of type `int64` must be set to a value that allows for comparing relative weights of the allocations, such as allocation size in bytes
 
 For each `cpu` sample:
 


### PR DESCRIPTION
For allocation profiling we wish to use [ObjectAllocationSample](https://bestsolution-at.github.io/jfr-doc/openjdk-17.html#jdk.ObjectAllocationSample) event that does not provide a allocation size in bytes
@gsmirnov-splk please review