### PR TITLE
Release lifecycle marking

### DIFF
--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -17,6 +17,15 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Version 0.1.0 - 2021-04-01
 
+### Life cycle status 
+
+Use one of:	
+-	*Latest*
+-	*Active*
+-	*Deprecated:* End of Support expected on 2024-04-01
+-	*End of Support:* Support has ended on 2024-04-01
+
+
 ### General
 
 - This release marks the first release of the repository.

--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -20,8 +20,7 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 ### Life cycle status 
 
 Use one of:	
--	*Latest*
--	*Active*
+-   *Supported*
 -	*Deprecated:* End of Support expected on 2024-04-01
 -	*End of Support:* Support has ended on 2024-04-01
 

--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -17,13 +17,7 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Version 0.1.0 - 2021-04-01
 
-### Life cycle status
-
-Use one of:
-
-- *Supported*
-- *Deprecated:* End of Support expected on 2024-04-01
-- *End of Support:* Support has ended on 2024-04-01
+Status: **Deprecated** (End of Support expected on 2024-04-01)
 
 ### General
 

--- a/specification/templates/CHANGELOG.md
+++ b/specification/templates/CHANGELOG.md
@@ -17,13 +17,13 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Version 0.1.0 - 2021-04-01
 
-### Life cycle status 
+### Life cycle status
 
-Use one of:	
--   *Supported*
--	*Deprecated:* End of Support expected on 2024-04-01
--	*End of Support:* Support has ended on 2024-04-01
+Use one of:
 
+- *Supported*
+- *Deprecated:* End of Support expected on 2024-04-01
+- *End of Support:* Support has ended on 2024-04-01
 
 ### General
 

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -86,25 +86,26 @@ delivered to the users. If the release is also distributed via other
 distribution channels (e.g. CDN, Registries, AppStores) it `MUST` state
 its life cycle status according to following rules by any means available
 in the given software distribution solution.
- 
-Each release `MUST` clearly state the life cycle 
-status and described as: Supported, Deprecated, End of Support. 
-At minimum the required information should be included in [CHAANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
-and equivalent mechanism provided by system used for distributing software. 
 
-If new version is released previously released versions `MUST` be evaluated 
+Each release `MUST` clearly state the life cycle
+status and described as: Supported, Deprecated, End of Support.
+At minimum the required information should be included in [CHAANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
+and equivalent mechanism provided by system used for distributing software.
+
+If new version is released previously released versions `MUST` be evaluated
 according to stability guarantees and marked as:
+
 - Latest release `SHOULD` be marked as **Supported** indicating that this is
   version recommended to new and existing users
-- If applicable latest release of previous `MAJOR` line that is still under 
-  active development `MUST` be marked as **Supported** indicating that previous 
-  `MAJOR` line is under active development and users not ready to adopt 
+- If applicable latest release of previous `MAJOR` line that is still under
+  active development `MUST` be marked as **Supported** indicating that previous
+  `MAJOR` line is under active development and users not ready to adopt
   latest `MAJOR` version may use previous versions.
-- Release which was superseded by newer version, thus has entered deprecation 
-  period `MUST` be marked as **Deprecated** and `MUST` indicated planned 
-  end of support date. This indicates that users should plan for upgrade to 
+- Release which was superseded by newer version, thus has entered deprecation
+  period `MUST` be marked as **Deprecated** and `MUST` indicated planned
+  end of support date. This indicates that users should plan for upgrade to
   one of supported versions before date given.
-- Release which deprecation period has ended `MUST` be marked as 
-  **End of support** and `MUST` indicate date on which the release was marked 
-  as end of support. This indicates that support for given release is no longer 
+- Release which deprecation period has ended `MUST` be marked as
+  **End of support** and `MUST` indicate date on which the release was marked
+  as end of support. This indicates that support for given release is no longer
   provided and the users should immediately upgrade to newer supported version.

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -80,11 +80,12 @@ until the end of that component’s existence:
 
 ## Release life cycle management
 
-Each repository `MUST` use [GitHub releases mechanism](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) to create snapshot of components
-and features delivered to the users. If release is also distributed via other 
-distribution channels (e.g. CDN, Registries, AppStores) it `MUST` be described 
-according to following rules by any means available in the given software 
-distribution solution. 
+Each repository `MUST` use [GitHub releases mechanism](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+to create a versioned snapshot of components and features
+delivered to the users. If the release is also distributed via other
+distribution channels (e.g. CDN, Registries, AppStores) it `MUST` state
+its life cycle status according to following rules by any means available
+in the given software distribution solution.
  
 Each release `MUST` clearly state the life cycle 
 status and described as: Active, Latest, Deprecated, End of Support. 

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -87,23 +87,23 @@ according to following rules by any means available in the given software
 distribution solution. 
  
 Each release `MUST` clearly state the life cycle 
-status and described as: Active, Latest, Deprecated, End of Support. 
+status and described as: Supported, Deprecated, End of Support. 
 At minimum the required information should be included in [CHAANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
 and equivalent mechanism provided by system used for distributing software. 
 
 If new version is released previously released versions `MUST` be evaluated 
 according to stability guarantees and marked as:
-- Latest release `SHOULD` be marked as **Latest** indicating that this is
+- Latest release `SHOULD` be marked as **Supported** indicating that this is
   version recommended to new and existing users
 - If applicable latest release of previous `MAJOR` line that is still under 
-  active development `MUST` be marked as **Active** indicating that previous 
+  active development `MUST` be marked as **Supported** indicating that previous 
   `MAJOR` line is under active development and users not ready to adopt 
   latest `MAJOR` version may use previous versions.
 - Release which was superseded by newer version, thus has entered deprecation 
   period `MUST` be marked as **Deprecated** and `MUST` indicated planned 
   end of support date. This indicates that users should plan for upgrade to 
-  latest or active version respectively before date given.
+  one of supported versions before date given.
 - Release which deprecation period has ended `MUST` be marked as 
   **End of support** and `MUST` indicate date on which the release was marked 
   as end of support. This indicates that support for given release is no longer 
-  provided and the users should immediately upgrade to newer version.
+  provided and the users should immediately upgrade to newer supported version.

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -77,3 +77,33 @@ until the end of that component’s existence:
   MUST be provided as the latest `PATCH` version for the latest `MINOR` version
   of the latest `MAJOR` and SHOULD NOT be provided for previous `PATCH` or
   `MINOR` releases.
+
+## Release life cycle management
+
+Each repository `MUST` use [GitHub releases mechanism](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) to create snapshot of components
+and features delivered to the users. If release is also distributed via other 
+distribution channels (e.g. CDN, Registries, AppStores) it `MUST` be described 
+according to following rules by any means available in the given software 
+distribution solution. 
+ 
+Each release `MUST` clearly state the life cycle 
+status and described as: Active, Latest, Deprecated, End of Support. 
+At minimum the required information should be included in [CHAANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
+and equivalent mechanism provided by system used for distributing software. 
+
+If new version is released previously released versions `MUST` be evaluated 
+according to stability guarantees and marked as:
+- Latest release `SHOULD` be marked as **Latest** indicating that this is
+  version recommended to new and existing users
+- If applicable latest release of previous `MAJOR` line that is still under 
+  active development `MUST` be marked as **Active** indicating that previous 
+  `MAJOR` line is under active development and users not ready to adopt 
+  latest `MAJOR` version may use previous versions.
+- Release which was superseded by newer version, thus has entered deprecation 
+  period `MUST` be marked as **Deprecated** and `MUST` indicated planned 
+  end of support date. This indicates that users should plan for upgrade to 
+  latest or active version respectively before date given.
+- Release which deprecation period has ended `MUST` be marked as 
+  **End of support** and `MUST` indicate date on which the release was marked 
+  as end of support. This indicates that support for given release is no longer 
+  provided and the users should immediately upgrade to newer version.

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -89,7 +89,8 @@ in the given software distribution solution.
  
 Each release `MUST` clearly state the life cycle 
 status and described as: Active, Latest, Deprecated, End of Support. 
-At minimum the required information should be included in [CHAANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
+At minimum the required information should be included in 
+[CHANGELOG.md](https://github.com/signalfx/gdi-specification/blob/main/specification/templates/CHANGELOG.md)
 and equivalent mechanism provided by system used for distributing software. 
 
 If new version is released previously released versions `MUST` be evaluated 


### PR DESCRIPTION
Initial proposal for rules for marking status of released version. It will allow to clearly define window of support (all releases currently supported)  and pass the information to the end users. 
If the change is accepted we all released versions described in the changelog should be updated with appropriate status 