### PR TITLE
Release 1.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/ga_request.md
+++ b/.github/ISSUE_TEMPLATE/ga_request.md
@@ -11,16 +11,16 @@ assignees: ''
 
 Name and link to repository
 
-### Does the repository follow the latest tagged minor release in [GDI specification](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md)?
+### Does the repository follow the latest tagged minor release in [GDI specification](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md)?
 
-- [ ] Has an appropriate [maintainers team](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#teams).
-- [ ] [Permissions](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#permissions) set correctly.
-- [ ] [Branch protection](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#branch-protection) in place.
-- [ ] [Dependencies](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#dependencies) appropriately locked down.
-- [ ] [GitHub Applications](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#github-applications) set up per spec.
-- [ ] Follows the [configuration requirements](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/configuration.md), if appropriate.
-- [ ] Follows the [semantic convention requirements](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/semantic_conventions.md), if appropriate.
-- [ ] [Required Files](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#required-files) in place.
+- [ ] Has an appropriate [maintainers team](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#teams).
+- [ ] [Permissions](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#permissions) set correctly.
+- [ ] [Branch protection](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#branch-protection) in place.
+- [ ] [Dependencies](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#dependencies) appropriately locked down.
+- [ ] [GitHub Applications](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#github-applications) set up per spec.
+- [ ] Follows the [configuration requirements](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/configuration.md), if appropriate.
+- [ ] Follows the [semantic convention requirements](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/semantic_conventions.md), if appropriate.
+- [ ] [Required Files](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#required-files) in place.
   - [ ] CHANGELOG.md
   - [ ] CODE_OF_CONDUCT.md
   - [ ] CONTRIBUTING.md
@@ -33,17 +33,17 @@ Name and link to repository
     - [ ] Link to official Splunk docs
     - [ ] License information
   - [ ] SECURITY.md
-- [ ] [Releases](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#github-releases) done to spec.
+- [ ] [Releases](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#github-releases) done to spec.
 - [ ] Type specific requirements (remove what doesn't apply)
-  - [ ] [Data Collector](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#data-collector)
+  - [ ] [Data Collector](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#data-collector)
     - [ ] Documents all supported configuration parameters.
     - [ ] Documents sizing guidelines
-  - [ ] [Instrumentation Library](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#instrumentation-libraries)
+  - [ ] [Instrumentation Library](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#instrumentation-libraries)
     - [ ] Documents all supported configuration parameters.
     - [ ] Documents how to configure manual instrumentation.
     - [ ] Documents how to configure log correlation.
     - [ ] Documents minimum supported version of each auto-instrumentation framework.
-  - [ ] [Real User Monitoring Library](https://github.com/signalfx/gdi-specification/blob/v1.4.0/specification/repository.md#real-user-monitoring-libraries)
+  - [ ] [Real User Monitoring Library](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/repository.md#real-user-monitoring-libraries)
     - [ ] Documents all supported configuration parameters.
     - [ ] Documents how to configure manual instrumentation.
     - [ ] Documents supported instrumentation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           args: -v -n "*.md" "**/*.md"
           fail: true
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'release PR') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+## [1.5.0] - 2023-03-30
+
+### Configuration
+
+#### Bugfixes
+
+- Remove `SPLUNK_METRICS_ENDPOINT` from Instrumentation Libraries
+  (it was never really stable).
+
+#### Enhancements
+
+- Add `SPLUNK_PROFILER_MEMORY_ENABLED`.
+- Deprecate `jaeger-thrift-splunk` option for `OTEL_TRACES_EXPORTER`.
+- Remove the policy regarding Zipkin exporter.
+- OTLP exporter can use either `grpc` or `http/protobuf`
+  as the default transport protocol.
+
+### Repository
+
+#### Enhancements
+
+- Add tag protection rule requirement.
+- Add Dependabot security configuration requirements.
+- Grant Admin role for maintainers team.
+- Refine documentation requirements.
+
+### Semantic Conventions
+
+#### Breaking Changes
+
+- Remove `telemetry.sdk.language` attribute from `ResourceLogs.resource`.
+
+### Bugfixes
+
+- Remove redunant and conflicting statement about file and line for `ResourceLogs`.
+
+#### Enhancements
+
+- Recommened adding `container.id`, `host.id`, `process.pid` attributes
+  to `ResourceLogs.resource`.
+- Recommend setting process resource attributes.
+- Recommend collecting runtime environment metrics.
+- Add a required `profiling.data.total.frame.count` attribute to `LogRecord` for `pprof-gzip-base64`.
+- Relax the meaning of `allocation` in `LogRecord` for `pprof-gzip-base64`.
+
 ## [1.4.0] - 2022-08-16
 
 ### Configuration
@@ -182,7 +227,8 @@
 - Primary focus is on Instrumentation Libraries for initial 1.0 release
 - Initial Collector specification defined
 
-[Unreleased]: https://github.com/signalfx/gdi-specification/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/signalfx/gdi-specification/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/signalfx/gdi-specification/releases/tag/v1.5.0
 [1.4.0]: https://github.com/signalfx/gdi-specification/releases/tag/v1.4.0
 [1.3.0]: https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0
 [1.2.0]: https://github.com/signalfx/gdi-specification/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
   to `ResourceLogs.resource`.
 - Recommend setting process resource attributes.
 - Recommend collecting runtime environment metrics.
-- Add a required `profiling.data.total.frame.count` attribute to `LogRecord` for `pprof-gzip-base64`.
+- Add a required `profiling.data.total.frame.count` attribute
+  to `LogRecord` for `pprof-gzip-base64`.
 - Relax the meaning of `allocation` in `LogRecord` for `pprof-gzip-base64`.
 
 ## [1.4.0] - 2022-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@
 - Add tag protection rule requirement.
 - Add Dependabot security configuration requirements.
 - Grant Admin role for maintainers team.
-- Refine documentation requirements.
+- Allow using the documentation public repository
+  and reference it in the `CONTRIBUTING.md` template.
+- Require documenting all configuration parameters
+  that are relevant to Splunk Observability Cloud.
+- Require documenting all configuration parameters
+  whose default or accepted values deviate from upstream.
 
 ### Semantic Conventions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,8 @@
 
 1. Update [CHANGELOG.md](CHANGELOG.md) with new the new release.
 
-2. Push the changes to upstream and create a Pull Request on GitHub.
+2. Create a pull request with `release PR` label on GitHub
+   with the changes described in the changelog.
 
 ## Tag
 


### PR DESCRIPTION
### Configuration

#### Bugfixes

- Remove `SPLUNK_METRICS_ENDPOINT` from Instrumentation Libraries
  (it was never really stable).

#### Enhancements

- Add `SPLUNK_PROFILER_MEMORY_ENABLED`.
- Deprecate `jaeger-thrift-splunk` option for `OTEL_TRACES_EXPORTER`.
- Remove the policy regarding Zipkin exporter.
- OTLP exporter can use either `grpc` or `http/protobuf`
  as the default transport protocol.

### Repository

#### Enhancements

- Add tag protection rule requirement.
- Add Dependabot security configuration requirements.
- Grant Admin role for maintainers team.
- Allow using the documentation public repository
  and reference it in the `CONTRIBUTING.md` template.
- Require documenting all configuration parameters
  that are relevant to Splunk Observability Cloud.
- Require documenting all configuration parameters
  whose default or accepted values deviate from upstream.

### Semantic Conventions

#### Breaking Changes

- Remove `telemetry.sdk.language` attribute from `ResourceLogs.resource`.

### Bugfixes

- Remove redunant and conflicting statement about file and line for `ResourceLogs`.

#### Enhancements

- Recommened adding `container.id`, `host.id`, `process.pid` attributes
  to `ResourceLogs.resource`.
- Recommend setting process resource attributes.
- Recommend collecting runtime environment metrics.
- Add a required `profiling.data.total.frame.count` attribute to `LogRecord` for `pprof-gzip-base64`.
- Relax the meaning of `allocation` in `LogRecord` for `pprof-gzip-base64`.
