### PR TITLE
Add a SPLUNK_{COMPONENT}_ prefix recommendation

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -31,7 +31,7 @@ exhibited when considering repository-specific configuration variables.
 
 Splunk-specific configuration variables defined in the GDI specification MUST
 be prefixed with `SPLUNK_`. Furthermore, configuration specific to Splunk
-Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_`, to Splunk
+Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_` and to Splunk
 Enterprise or Splunk Cloud MUST be prefixed with `SPLUNK_PLATFORM_`.
 Confiugration unique to a specific GDI component (e.g. connected with a lanaguge
 feature) SHOULD be prefixed with `SPLUNK_{COMPONENT}_` (e.g. `SPLUNK_JAVA_`).

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -31,9 +31,11 @@ exhibited when considering repository-specific configuration variables.
 
 Splunk-specific configuration variables defined in the GDI specification MUST
 be prefixed with `SPLUNK_`. Furthermore, configuration specific to Splunk
-Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_` and to Splunk
-Enterprise or Splunk Cloud MUST be prefixed with `SPLUNK_PLATFORM_`. If a
-Splunk-specific configuration variable is declared as stable in the GDI
+Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_`, to Splunk
+Enterprise or Splunk Cloud MUST be prefixed with `SPLUNK_PLATFORM_`.
+Confiugration unique to a specific GDI component (e.g. connected with a lanaguge
+feature) SHOULD be prefixed with `SPLUNK_{COMPONENT}_` (e.g. `SPLUNK_JAVA_`).
+If a Splunk-specific configuration variable is declared as stable in the GDI
 specification and later the OpenTelemetry specification declares a similar
 variable as stable, the GDI specification MUST adopt the OpenTelemetry
 configuration variable and SHOULD mark the GDI specification configuration

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -33,7 +33,7 @@ Splunk-specific configuration variables defined in the GDI specification MUST
 be prefixed with `SPLUNK_`. Furthermore, configuration specific to Splunk
 Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_` and to Splunk
 Enterprise or Splunk Cloud MUST be prefixed with `SPLUNK_PLATFORM_`.
-Confiugration unique to a specific GDI component (e.g. connected with a lanaguge
+Configuration unique to a specific GDI component (e.g. connected with a lanaguge
 feature) SHOULD be prefixed with `SPLUNK_{COMPONENT}_` (e.g. `SPLUNK_JAVA_`).
 If a Splunk-specific configuration variable is declared as stable in the GDI
 specification and later the OpenTelemetry specification declares a similar

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -33,7 +33,7 @@ Splunk-specific configuration variables defined in the GDI specification MUST
 be prefixed with `SPLUNK_`. Furthermore, configuration specific to Splunk
 Observability Cloud MUST be prefixed with `SPLUNK_OBSERVABILITY_` and to Splunk
 Enterprise or Splunk Cloud MUST be prefixed with `SPLUNK_PLATFORM_`.
-Configuration unique to a specific GDI component (e.g. connected with a lanaguge
+Configuration unique to a specific GDI component (e.g. connected with a language
 feature) SHOULD be prefixed with `SPLUNK_{COMPONENT}_` (e.g. `SPLUNK_JAVA_`).
 If a Splunk-specific configuration variable is declared as stable in the GDI
 specification and later the OpenTelemetry specification declares a similar


### PR DESCRIPTION
## Why

Fixes https://github.com/signalfx/gdi-specification/issues/198

I want to close the issue and I think that this recommendation should be good enough.

## What

Added:

>  Configuration unique to a specific GDI component (e.g. connected with a language
feature) SHOULD be prefixed with `SPLUNK_{COMPONENT}_` (e.g. `SPLUNK_JAVA_`).
