### PR TITLE
Add labels proposal to changelog requirements

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -96,8 +96,6 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).
-  - Each change coming from upstream MUST bear a label that indicates where the
-    change is coming from. For example: `(Contrib)` or `(Core)`.
   - The CHANGELOG.md SHOULD NOT list every PR, but only changes significant
     from an end-user point of view. Anyone who is interested in all the details
     of every change in the repository can use the git log for that.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -89,7 +89,8 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     area (if applicable).
   - Each change MUST bear a label that indicates where the change is coming from.
     For example, `(Contrib)`, `(Core)`, or `(Splunk)`.
-  The following sub-sections MAY be used, as appropriate or specified.
+
+  The following sub-sections MAY be used, as appropriate or specified:
     - `General` - General comments about the release that users should know about.
     - `Breaking Changes` - Any changes that will break backward compatibility
       with previous versions. MUST list all breaking changes.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -89,7 +89,7 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
   - Each release MUST contain a link to the upstream release notes.
-  - Each release SHOULD contain a list of changes from upstream that Splunk has
+  - Each release MAY contain a list of changes from upstream that Splunk has
     been working on, are relevant to Splunk GDI, or fix outstanding bugs.
   - Each change coming from upstream MUST bear a label that indicates where the
     change is coming from. For example: `(Contrib)` or `(Core)`.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -81,9 +81,9 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
-  - Each release MUST contain a list of relevant changes, including those from upstream
-    that are relevant to Splunk, either because they add a feature or because they fix
-    longstanding bugs reported by users.
+  - Each release MUST contain a list of relevant changes, including those
+    from upstream that are relevant to Splunk, either because they add a
+    feature or because they fix longstanding bugs reported by users.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -81,6 +81,7 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
+  - Each change MUST bear a label that indicates where the change is coming from: `(Contrib)`, `(Core)`, or `(Splunk)`.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -94,8 +94,8 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).
-  - Each change MUST bear a label that indicates where the change is coming from.
-    For example, `(Contrib)`, `(Core)`, or `(Splunk)`.
+  - Each change coming from upstream MUST bear a label that indicates where the
+    change is coming from. For example: `(Contrib)` or `(Core)`.
   - The CHANGELOG.md SHOULD NOT list every PR, but only changes significant
     from an end-user point of view. Anyone who is interested in all the details
     of every change in the repository can use the git log for that.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -77,6 +77,13 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 - MUST have a [CHANGELOG.md](templates/CHANGELOG.md) updated for every release
   - The `CHANGELOG.md` is intended to be consumed by humans, and not machines.
+  - The following sub-sections MAY be used, as appropriate or specified:
+    - `General` - General comments about the release that users should know about.
+    - `Breaking Changes` - Any changes that will break backward compatibility
+      with previous versions. MUST list all breaking changes.
+    - `Bugfixes` - Details of bugs that were fixed. SHOULD list all bug fixes.
+    - `Enhancements` - New features that have been added to the repository. SHOULD
+      list all new features.
   - The file SHOULD contain an `Unreleased` section at the top, which includes
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
@@ -89,14 +96,6 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     area (if applicable).
   - Each change MUST bear a label that indicates where the change is coming from.
     For example, `(Contrib)`, `(Core)`, or `(Splunk)`.
-
-  The following sub-sections MAY be used, as appropriate or specified:
-    - `General` - General comments about the release that users should know about.
-    - `Breaking Changes` - Any changes that will break backward compatibility
-      with previous versions. MUST list all breaking changes.
-    - `Bugfixes` - Details of bugs that were fixed. SHOULD list all bug fixes.
-    - `Enhancements` - New features that have been added to the repository. SHOULD
-      list all new features.
   - The CHANGELOG.md SHOULD NOT list every PR, but only changes significant
     from an end-user point of view. Anyone who is interested in all the details
     of every change in the repository can use the git log for that.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -81,12 +81,14 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
-  - Each release MUST contain a list of relevant changes, including those from upstream.
+  - Each release MUST contain a list of relevant changes, including those from upstream
+    that are relevant to Splunk, either because they add a feature or because they fix
+    longstanding bugs reported by users.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).
-  - Each change MUST bear a label that indicates where the change is coming from:
-    `(Contrib)`, `(Core)`, or `(Splunk)`.
+  - Each change MUST bear a label that indicates where the change is coming from.
+    For example, `(Contrib)`, `(Core)`, or `(Splunk)`.
   The following sub-sections MAY be used, as appropriate or specified.
     - `General` - General comments about the release that users should know about.
     - `Breaking Changes` - Any changes that will break backward compatibility

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -88,9 +88,11 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
+  - Each release MUST contain a link to the upstream release notes.
   - Each release SHOULD contain a list of changes from upstream that Splunk has
     been working on, are relevant to Splunk GDI, or fix outstanding bugs.
-  - Each release MUST contain a link to the upstream release notes.
+  - Each change coming from upstream MUST bear a label that indicates where the
+    change is coming from. For example: `(Contrib)` or `(Core)`.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -81,9 +81,9 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
-  - Each release MUST contain a list of relevant changes, including those
-    from upstream that are relevant to Splunk, either because they add a
-    feature or because they fix longstanding bugs reported by users.
+  - Each release SHOULD contain a list of changes from upstream that Splunk has
+    been working on, are relevant to Splunk GDI, or fix outstanding bugs.
+  - Each release MUST contain a link to the upstream release notes.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -81,10 +81,12 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
     changes that have not yet been released.
   - The file MUST be in reverse chronological order, with the most recent
     releases at the top of the file, after the `Unreleased` section.
-  - Each change MUST bear a label that indicates where the change is coming from: `(Contrib)`, `(Core)`, or `(Splunk)`.
+  - Each release MUST contain a list of relevant changes, including those from upstream.
   - Each release SHOULD be separated by a line separator (`---`) from the other relases.
   - Each release SHOULD contain separate sections for each major functionality
     area (if applicable).
+  - Each change MUST bear a label that indicates where the change is coming from:
+    `(Contrib)`, `(Core)`, or `(Splunk)`.
   The following sub-sections MAY be used, as appropriate or specified.
     - `General` - General comments about the release that users should know about.
     - `Breaking Changes` - Any changes that will break backward compatibility


### PR DESCRIPTION
This adds a proposal for labeling changes in the CHANGELOG.md file so as to better distinguish which are coming from upstream as opposed to our repos.

Example: https://github.com/signalfx/splunk-otel-collector/blob/main/CHANGELOG.md