### PR TITLE
Update semantic conventions for RUM

### DIFF
--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -28,9 +28,6 @@ All Splunk distributions of OpenTelemetry,
 
 - SHOULD set [process and process runtime resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/resource/semantic_conventions/process.md)
 
-Note: this section does not apply to Real User Monitoring libraries, as they do
-not use the OpenTelemetry Resource.
-
 ## Splunk Resource Attributes
 
 **Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
@@ -41,9 +38,6 @@ version in combination with OpenTelemetry's `telemetry.sdk.*` attributes.
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `splunk.distro.version` | string | The version number of the Splunk distribution being used. | `1.5.0` | Yes |
-
-Note: this section does not apply to Real User Monitoring libraries, as they do
-not use the OpenTelemetry Resource.
 
 ## Runtime Environment Metrics
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -53,9 +53,7 @@ when metrics are enabled.
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
 
 Real User Monitoring (RUM) libraries MUST set the `service.name` resource
-attribute to the value of the `applicationName` configuration property. This is
-the only resource attribute that RUM libraries are supposed to set because it's
-the only one the Zipkin exporter can understand.
+attribute to the value of the `applicationName` configuration property.
 
 The following attributes MUST be added to all spans produced by RUM libraries:
 


### PR DESCRIPTION
Related to https://github.com/signalfx/gdi-specification/issues/242

AFAIK RUM uses OTel Resources which are then send as tags via Zipkin exporter.

From https://github.com/signalfx/gdi-specification/blob/main/specification/semantic_conventions.md

> This is the only resource attribute that RUM libraries are supposed to set because it's the only one the Zipkin exporter can understand.

I am not sure it this is true.

Also shouldn't we set `splunk.distro.version` instead of `splunk.rum.version`?

@t2t2 @seemk PTAL

PS. Feel free to edit or create a better PR 😉 