### PR TITLE
Mark RUM config as Experimental

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -254,7 +254,7 @@ In addition to environment variables, other ways of defining configuration also 
 
 ### Real User Monitoring Libraries
 
-**Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
+**Status**: [Expermiental](../README.md#versioning-and-status-of-the-specification)
 
 Real User Monitoring (RUM) instrumentation libraries cannot use environment
 variables for configuration. Instead, they MUST expose a `SplunkRum`


### PR DESCRIPTION
I know that the section is marked as "Stable". But I believe it is still Experimental.

Related to https://github.com/signalfx/gdi-specification/issues/246

@t2t2 @seemk do you agree?

This would revert https://github.com/signalfx/gdi-specification/pull/180