### PR TITLE
Change wording for span connection limits

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -227,7 +227,7 @@ are required.
     (not OpenTelemetry default)
   - Distribution MUST default to `12000` for `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`
     (not OpenTelemetry default)
-  - Distribution MUST default to unset (unlimited) for all others
+  - Distribution MUST default to unlimited for all others
     (not OpenTelemetry default)
 - `OTEL_TRACES_EXPORTER`
   - Non-RUM distribution MUST default to `otlp` using `grpc` or `http/protobuf`


### PR DESCRIPTION
Based on previous wording we have made it unset in .NET (defaulting OTel values) for all other variables.

Ref links:
* .NET https://github.com/signalfx/splunk-otel-dotnet/blob/f9146737017242c8d74572feec719b1e8f9baa58/src/Splunk.OpenTelemetry.AutoInstrumentation/SdkLimitOptionsConfigurator.cs#L29-L40
* Java https://github.com/signalfx/splunk-otel-dotnet/blob/f9146737017242c8d74572feec719b1e8f9baa58/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SdkLimitOptionsConfiguratorTests.cs#L21
* Go-lang https://github.com/signalfx/splunk-otel-go/blob/b78a37105554d81d0cbb4b793aff8c448f1e776f/distro/limits.go#L62