### PR TITLE
Add CLA Assistant GitHub workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  statuses: read
+
+jobs:
+  ContributorLicenseAgreement:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
+        with:
+          remote-organization-name: splunk
+          remote-repository-name: cla-agreement
+          branch: main
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/splunk/cla-agreement/blob/main/CLA.md
+          allowlist: dependabot


### PR DESCRIPTION
Towards https://github.com/signalfx/gdi-specification/issues/236

Add CLA Assistant GitHub workflow to this repository.

Testing here: https://github.com/pellared/test-cla/pull/1 as I do NOT want to change the default branch in this repository for sake of testing.
Test passed: https://github.com/splunk/cla-agreement/commit/28bce313e329c76f03f92fc0d2f358a3dcf113d8

Next steps
1. Add a requirement to have a CLA GitHub workflow here: https://github.com/signalfx/gdi-specification/blob/add-cla/specification/repository.md#github-actions
2. Add CLA GitHub workflow to other repositories.