### PR TITLE
Update cla.yml permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,10 +6,10 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   pull-requests: write
-  statuses: read
+  statuses: write
 
 jobs:
   ContributorLicenseAgreement:


### PR DESCRIPTION
## What

Add missing permissions.

## Why

I read https://github.com/contributor-assistant/github-action source code and it needs `write` on `actions` (see [here](https://github.com/contributor-assistant/github-action/blob/a895a435fcce79ecf28fbce61a4ef0f0dabc9853/src/pullRerunRunner.ts#L21-L24)) and `write` on `statuses`  (see [here](https://github.com/contributor-assistant/github-action/blob/a895a435fcce79ecf28fbce61a4ef0f0dabc9853/src/pullrequest/signatureComment.ts#L43-L45)).

`write` on `contents` should not be needed when signatures are stored in a remote repository.

PS. I created https://github.com/contributor-assistant/github-action/pull/144