### PR TITLE
Add renovatebot as a dependency management option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Require a CLA Assistant GitHub workflow. (#269)
 - Update the CLA notice in `CONTRIBUTING.md` template. (#269)
-- Add Renovate as an acceptable alternative to Dependabot (#271)
+- Add Renovate as an acceptable alternative to Dependabot. (#271)
 
 ## [1.6.0] - 2023-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Require a CLA Assistant GitHub workflow. (#269)
 - Update the CLA notice in `CONTRIBUTING.md` template. (#269)
+- Add Renovate as an acceptable alternative to Dependabot (#271)
 
 ## [1.6.0] - 2023-09-14
 

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -54,20 +54,22 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 - MUST lock the versions of all build dependencies (e.g. libraries, binaries,
   scripts, docker images) or vendor them; **EXCEPTION:** tools that are
   available out-of-the-box on the CI runner
-- To help keep dependencies up to date, the repo MUST be configured with 
+- To help keep dependencies up to date, the repo MUST be configured with
 [Dependabot](https://github.com/dependabot/dependabot-core) or [Renovate](https://github.com/apps/renovate).
 
-#### Dependabot:
+#### Dependabot
 
 - MUST enable [Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)
   - MUST grant access to alerts for the approvers and maintainers teams
   - MUST enable [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)
 - MUST configure [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)
 
-#### Renovate:
+#### Renovate
 
 - MUST add the repo to the [list of Renovatebot repos](https://github.com/organizations/signalfx/settings/installations/41531652).
-- MUST add a [Renovate config file](https://docs.renovatebot.com/configuration-options/) to the repo.
+- MUST add a 
+[Renovate config file](https://docs.renovatebot.com/configuration-options/)
+to the repo.
 
 ### GitHub Actions
 

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -67,7 +67,7 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 #### Renovate
 
 - MUST add the repo to the [list of Renovatebot repos](https://github.com/organizations/signalfx/settings/installations/41531652).
-- MUST add a 
+- MUST add a
 [Renovate config file](https://docs.renovatebot.com/configuration-options/)
 to the repo.
 

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -54,10 +54,20 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 - MUST lock the versions of all build dependencies (e.g. libraries, binaries,
   scripts, docker images) or vendor them; **EXCEPTION:** tools that are
   available out-of-the-box on the CI runner
+- To help keep dependencies up to date, the repo MUST be configured with 
+[Dependabot](https://github.com/dependabot/dependabot-core) or [Renovate](https://github.com/apps/renovate).
+
+#### Dependabot:
+
 - MUST enable [Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)
   - MUST grant access to alerts for the approvers and maintainers teams
   - MUST enable [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)
 - MUST configure [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)
+
+#### Renovate:
+
+- MUST add the repo to the [list of Renovatebot repos](https://github.com/organizations/signalfx/settings/installations/41531652).
+- MUST add a [Renovate config file](https://docs.renovatebot.com/configuration-options/) to the repo.
 
 ### GitHub Actions
 


### PR DESCRIPTION
The otel upstream repos for java and android are using Renovatebot. It as a few advantages, including combined PRs and maintenenance of a summary issue for dependencies. I'd like to switch over to it in our splunk java GDI repos as well.