### PR TITLE
Update telemetry resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Add disk buffering configuration options for RUM mobile instrumentation
   libraries. (#275)
 - Update telemetry resource attributes (#277):
-
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Add Renovate as an acceptable alternative to Dependabot. (#271)
 - Add disk buffering configuration options for RUM mobile instrumentation
   libraries. (#275)
+- Update telemetry resource attributes (#277):
+
+  - Deprecate `splunk.distro.version`,
+  - Change `telemetry.auto.version` to `telemetry.distro.version`,
+  - Add `telemetry.distro.name` resource attribute.
 
 ## [1.6.0] - 2023-09-14
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -24,7 +24,8 @@ All Splunk distributions of OpenTelemetry,
   - `telemetry.sdk.language`
 
 - SHOULD set the following resource attributes when applicable:
-  - `telemetry.auto.version`
+  - `telemetry.distro.name`
+  - `telemetry.distro.version`
 
 - SHOULD set [process and process runtime resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/resource/semantic_conventions/process.md)
 
@@ -33,7 +34,7 @@ not use the OpenTelemetry Resource.
 
 ## Splunk Resource Attributes
 
-**Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
+**Status**: [Deprecated](../README.md#versioning-and-status-of-the-specification)
 
 **Description:** Set of attributes used to uniquely identify a Splunk distro
 version in combination with OpenTelemetry's `telemetry.sdk.*` attributes.


### PR DESCRIPTION
Fixes #267.

Adjust our requirements to https://github.com/open-telemetry/semantic-conventions/pull/178

- Deprecate `splunk.distro.version`, - As it can be replaced by `telemetry.auto.version` and `telemetry.distro.name`. 
- Change `telemetry.auto.version` to `telemetry.distro.version`, - technically not a breaking change, as it was marked as SHOULD
- Add `telemetry.distro.name` resource attribute. - new attribute, not breaking change