### PR TITLE
Clarify default sampling algorithm

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -223,6 +223,8 @@ are required.
 - `OTEL_TRACES_EXPORTER`
   - Non-RUM distribution MUST default to `otlp` over gRPC with an endpoint of `localhost:4317`
   - Non-RUM distribution MUST offer `jaeger-thrift-splunk` that defaults to `http://127.0.0.1:9080/v1/trace`
+- `OTEL_TRACES_SAMPLER`
+  - Distribution MUST default to `always_on`.
 
 In addition to environment variables, other ways of defining configuration also exist:
 


### PR DESCRIPTION
OpenTelemetry defaults to `parentbased_always_on`, but this is not consistent across our distributions:
* `parentbased_always_on` is used by Node.js, .NET, Python
* `always_on` is used by Java

If we are advertising as a no sampling solution, we should default to `always_on`, but still allow for customers to change it.
Using `parentbased_always_on` can cause data loss if customers have previously set up cloud tracing, which injects a `traceparent` with `00` for `traceflags`.