### PR TITLE
Clarify default sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 #### Enhancements
 
-- Clarify the default sampling algorithm. (#284)[https://github.com/signalfx/gdi-specification/pull/284]
-- Require a CLA Assistant GitHub workflow. (#269)[https://github.com/signalfx/gdi-specification/pull/269]
-- Update the CLA notice in `CONTRIBUTING.md` template. (#269)[https://github.com/signalfx/gdi-specification/pull/269] (#274)[https://github.com/signalfx/gdi-specification/pull/274]
-- Add Renovate as an acceptable alternative to Dependabot. (#271)[https://github.com/signalfx/gdi-specification/pull/271]
+- Clarify the default sampling algorithm. [#284](https://github.com/signalfx/gdi-specification/pull/284)
+- Require a CLA Assistant GitHub workflow. [#269](https://github.com/signalfx/gdi-specification/pull/269)
+- Update the CLA notice in `CONTRIBUTING.md` template. [#269](https://github.com/signalfx/gdi-specification/pull/269) [#274](https://github.com/signalfx/gdi-specification/pull/274)
+- Add Renovate as an acceptable alternative to Dependabot. [#271](https://github.com/signalfx/gdi-specification/pull/271)
 - Add disk buffering configuration options for RUM mobile instrumentation
-  libraries. (#275)[https://github.com/signalfx/gdi-specification/pull/275]
-- Update telemetry resource attributes (#277)[https://github.com/signalfx/gdi-specification/pull/277]:
+  libraries. [#275](https://github.com/signalfx/gdi-specification/pull/275)
+- Update telemetry resource attributes [#277](https://github.com/signalfx/gdi-specification/pull/277):
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Enhancements
 
-- Clarify the default sampling algorithm. (#284)[https://github.com/signalfx/gdi-specification/pull/284)]
+- Clarify the default sampling algorithm. (#284)[https://github.com/signalfx/gdi-specification/pull/284]
 - Require a CLA Assistant GitHub workflow. (#269)[https://github.com/signalfx/gdi-specification/pull/269]
 - Update the CLA notice in `CONTRIBUTING.md` template. (#269)[https://github.com/signalfx/gdi-specification/pull/269] (#274)[https://github.com/signalfx/gdi-specification/pull/274]
 - Add Renovate as an acceptable alternative to Dependabot. (#271)[https://github.com/signalfx/gdi-specification/pull/271]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 
 #### Enhancements
 
-- Require a CLA Assistant GitHub workflow. (#269)
-- Update the CLA notice in `CONTRIBUTING.md` template. (#269, #274)
-- Add Renovate as an acceptable alternative to Dependabot. (#271)
+- Clarify the default sampling algorithm. (#284)[https://github.com/signalfx/gdi-specification/pull/284)]
+- Require a CLA Assistant GitHub workflow. (#269)[https://github.com/signalfx/gdi-specification/pull/269]
+- Update the CLA notice in `CONTRIBUTING.md` template. (#269)[https://github.com/signalfx/gdi-specification/pull/269] (#274)[https://github.com/signalfx/gdi-specification/pull/274]
+- Add Renovate as an acceptable alternative to Dependabot. (#271)[https://github.com/signalfx/gdi-specification/pull/271]
 - Add disk buffering configuration options for RUM mobile instrumentation
-  libraries. (#275)
-- Update telemetry resource attributes (#277):
+  libraries. (#275)[https://github.com/signalfx/gdi-specification/pull/275]
+- Update telemetry resource attributes (#277)[https://github.com/signalfx/gdi-specification/pull/277]:
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@
 
 #### Enhancements
 
-- Clarify the default sampling algorithm. [#284](https://github.com/signalfx/gdi-specification/pull/284)
-- Require a CLA Assistant GitHub workflow. [#269](https://github.com/signalfx/gdi-specification/pull/269)
-- Update the CLA notice in `CONTRIBUTING.md` template. [#269](https://github.com/signalfx/gdi-specification/pull/269) [#274](https://github.com/signalfx/gdi-specification/pull/274)
-- Add Renovate as an acceptable alternative to Dependabot. [#271](https://github.com/signalfx/gdi-specification/pull/271)
+- Clarify the default sampling algorithm.
+  [#284](https://github.com/signalfx/gdi-specification/pull/284)
+- Require a CLA Assistant GitHub workflow.
+  [#269](https://github.com/signalfx/gdi-specification/pull/269)
+- Update the CLA notice in `CONTRIBUTING.md` template.
+  [#269](https://github.com/signalfx/gdi-specification/pull/269)
+  [#274](https://github.com/signalfx/gdi-specification/pull/274)
+- Add Renovate as an acceptable alternative to Dependabot.
+  [#271](https://github.com/signalfx/gdi-specification/pull/271)
 - Add disk buffering configuration options for RUM mobile instrumentation
   libraries. [#275](https://github.com/signalfx/gdi-specification/pull/275)
-- Update telemetry resource attributes [#277](https://github.com/signalfx/gdi-specification/pull/277):
+- Update telemetry resource attributes
+  [#277](https://github.com/signalfx/gdi-specification/pull/277):
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -242,6 +242,8 @@ are required.
     OTLP exporter instead, or set the SPLUNK_REALM and SPLUNK_ACCESS_TOKEN environment variables to send 
     telemetry directly to Splunk Observability Cloud.
     ```
+- `OTEL_TRACES_SAMPLER`
+  - Distribution MUST default to `always_on`.
 
 In addition to environment variables, other ways of defining configuration also exist:
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -242,6 +242,7 @@ are required.
     OTLP exporter instead, or set the SPLUNK_REALM and SPLUNK_ACCESS_TOKEN environment variables to send 
     telemetry directly to Splunk Observability Cloud.
     ```
+
 - `OTEL_TRACES_SAMPLER`
   - Distribution MUST default to `always_on`.
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -244,7 +244,8 @@ are required.
     ```
 
 - `OTEL_TRACES_SAMPLER`
-  - Distribution MUST default to `always_on`.
+  - Distribution MUST default to `always_on`
+    (not OpenTelemetry default)
 
 In addition to environment variables, other ways of defining configuration also exist:
 


### PR DESCRIPTION
OpenTelemetry defaults to `parentbased_always_on`, but this is not consistent across our distributions:
* `parentbased_always_on` is used by Node.js, .NET, Python
* `always_on` is used by Java, [Go](https://github.com/signalfx/splunk-otel-go/blob/4b4f13d128bffd4035331cb84dc796a07b448803/distro/otel.go#L159)

If we are advertising as a no sampling solution, we should default to `always_on`, but still allow for customers to change it.
Using `parentbased_always_on` can cause data loss if customers have previously set up cloud tracing, which injects a `traceparent` with `00` for `traceflags`.