### PR TITLE
Deprecate `text` format for `profiling.data.format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.
+
+### Semantic Conventions
+
+#### Enhancements
+
 - Deprecate `text` format for `profiling.data.format`. (#285)
 
 ## [1.6.0] - 2023-09-14
@@ -73,7 +78,7 @@
 
 - Remove `telemetry.sdk.language` attribute from `ResourceLogs.resource`.
 
-### Bugfixes
+#### Bugfixes
 
 - Remove redunant and conflicting statement about file and line for `ResourceLogs`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.
-- Deprecate `text` format for `profiling.data.format` (#285).
+- Deprecate `text` format for `profiling.data.format`. (#285)
 
 ## [1.6.0] - 2023-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Deprecate `splunk.distro.version`,
   - Change `telemetry.auto.version` to `telemetry.distro.version`,
   - Add `telemetry.distro.name` resource attribute.
+- Deprecate `text` format for `profiling.data.format` (#285).
 
 ## [1.6.0] - 2023-09-14
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -125,7 +125,10 @@ instances. For each `LogRecord` instance:
 
 - `com.splunk.sourcetype` MUST be set to the value `otel.profiling`
 - `profiling.data.type` MUST be set to either `allocation` or `cpu`
-- `profiling.data.format` MUST be set to either `text` or `pprof-gzip-base64`
+- `profiling.data.format` MUST be set to either:
+  - `pprof-gzip-base64`,
+  - `text` ([deprecated](../README.md#versioning-and-status-of-the-specification)
+    format).
 
 #### `LogRecord` Message `text` Data Format Specific Attributes
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -127,7 +127,7 @@ instances. For each `LogRecord` instance:
 - `profiling.data.type` MUST be set to either `allocation` or `cpu`
 - `profiling.data.format` MUST be set to either:
   - `pprof-gzip-base64`,
-  - `text` ([deprecated](../README.md#versioning-and-status-of-the-specification)
+  - `text` ([Deprecated](../README.md#versioning-and-status-of-the-specification)
     format).
 
 #### `LogRecord` Message `text` Data Format Specific Attributes


### PR DESCRIPTION
As I remember it was already deprecated as the `text` format is inefficient.

@gsmirnov-splk, could you please confirm?