### PR TITLE
Create lychee GH issues only when action is failing

### DIFF
--- a/.github/workflows/lychee-weekly.yml
+++ b/.github/workflows/lychee-weekly.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           args: -v -n "*.md" "**/*.md"
       - name: Create Issue From File
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4.0.1
         with:
           title: Link Checker Report


### PR DESCRIPTION
Fixes: #288

Follows new recommendation how to execute weekly check:

https://github.com/lycheeverse/lychee-action/tree/c3089c702fbb949e3f7a8122be0c33c017904f9b#usage

Needed due to changes in 1.9.0 release: https://github.com/lycheeverse/lychee-action/pull/199