### PR TITLE
Relax repo name restrictions and include Cisco/AppD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ reading by GDI repository consumers.
   Refers to `splunk-otel-collector` repository.
 - GDI: Getting Data In
 - GDI repository: A repository in the `signalfx` GitHub that starts with
-  `splunk-otel-\*`
+  `splunk-otel-\*` or `o11y-\*`.
 - Instrumentation Library: A way to emit telemetry data from an application.
   Refers to `splunk-otel-<language>` repositories.
 - Maintainer: Someone responsible for the specification or a repository.
@@ -40,7 +40,7 @@ reading by GDI repository consumers.
 
 ## Notation Conventions and Compliance
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in the
 specification are to be interpreted as described
 in [BCP 14](https://tools.ietf.org/html/bcp14)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ reading by GDI repository consumers.
   Refers to `splunk-otel-collector` repository.
 - GDI: Getting Data In
 - GDI repository: A repository in the `signalfx` GitHub that starts with
-  `splunk-otel-\*` or `o11y-\*`.
+  `splunk-otel-\*` or `o11y-\*` and exists in [repositories.txt](repositories.txt).
 - Instrumentation Library: A way to emit telemetry data from an application.
   Refers to `splunk-otel-<language>` repositories.
 - Maintainer: Someone responsible for the specification or a repository.

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -11,14 +11,17 @@ approval is granted, GDI repositories MUST NOT cut a GA release.
 
 ### Teams
 
+Teams MUST only be comprised of full-time Cisco employees, which includes
+AppDynamics and Splunk employees.
+
 - MUST have an admins team and teams MAY be shared between repositories
   - MUST have `-admins` suffix
-  - MUST include at least two currently full-time Splunkers
-  - MUST NOT include any non-full-time Splunkers
-- MUST have a maintainers team and teams MAY be shared between repositories
+  - MUST include at least two current employees
+  - MUST NOT include any non-Cisco developers
+- MUST have a maintainers team, and teams MAY be shared between repositories
   - MUST have `-maintainers` suffix
-  - MUST include at least two currently full-time Splunkers
-  - MUST NOT include any non-full-time Splunkers
+  - MUST include at least two current employees
+  - MUST NOT include any non-Cisco developers
 - SHOULD have an approvers team and teams MAY be shared between repositories
   - MUST have `-approvers` suffix
 


### PR DESCRIPTION
We have a need to make a public facing repo for cross-team o11y collaboration that it not necessarily otel-specific. So to help with that, this PR:

* Expands the "GDI repository" terminology to include repos starting with `o11y-` and existing in `repositories.txt`
* Include all of Cisco and AppD and Splunk as team members.