### PR TITLE
Update SPLUNK_PROFILER_CALL_STACK_INTERVAL default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Configuration
+
+#### Enhancements
+
+- `SPLUNK_PROFILER_CALL_STACK_INTERVAL` defaults to `1000` for single-threaded runtimes.
+
 ### Repository
 
 #### Enhancements

--- a/specification/behaviors.md
+++ b/specification/behaviors.md
@@ -12,8 +12,7 @@ instrumentation libraries that contain profiling features.
 ### Call Stack Sampling
 
 An instrumentation library that has profiling capabilities MUST be able to
-sample call stacks at a fixed interval. This default interval MUST default to 10
-seconds.
+sample call stacks at a fixed interval.
 
 When a language runtime supports threading, stacks MUST be sampled across all
 process threads. The samples for all threads SHOULD be taken instantaneously

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -167,7 +167,7 @@ instance using the following environment variables:
 | Name                                   | Default | Description                                                                              |
 |----------------------------------------|---------|------------------------------------------------------------------------------------------|
 | `SPLUNK_ACCESS_TOKEN`                  |         | Access token added to exported data. [1]                                                 |
-| `SPLUNK_PROFILER_CALL_STACK_INTERVAL`  | 10000   | Interval at which call stacks are sampled (in ms) [5]                                    |
+| `SPLUNK_PROFILER_CALL_STACK_INTERVAL`  | [7]     | Interval at which call stacks are sampled (in ms) [5]                                    |
 | `SPLUNK_PROFILER_ENABLED`              | false   | Whether CPU profiling is enabled. [2] [5]                                                |
 | `SPLUNK_PROFILER_LOGS_ENDPOINT`        | *       | Where profiling data is sent. Defaults to the value in `OTEL_EXPORTER_OTLP_ENDPOINT` [5] |
 | `SPLUNK_PROFILER_MEMORY_ENABLED`       | false   | Whether memory profiling is enabled. [2] [6]                                             |
@@ -199,6 +199,7 @@ instance using the following environment variables:
   MUST be set to `true`.
 - [5]: Applies only to instrumentation libraries with CPU profiling capabilities.
 - [6]: Applies only to instrumentation libraries with memory profiling capabilities.
+- [7]: `10000` for multi-threaded runtimes, `1000` for single-threaded runtimes.
 
 In addition to Splunk-specific environment variables, the following
 [OpenTelemetry environment


### PR DESCRIPTION
Fixes #322 

The 1 second interval is currently used in our Node.js and Python distros. Java and .NET have 10 seconds.

The 10 second interval was meant for cases where threads might exist to limit the amount of data.