### PR TITLE
Refactor versioning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ document. Lifecycle stages are defined in the
 
 - [1]: See [stability guarantees](./specification/versioning.md) for details.
 
+## Experimental
+
+Everything in the specification starts as `Experimental`.
+
+`Experimental` sections SHOULD NOT be expected to be feature-complete.
+In some cases, the experiment MAY be discarded and removed entirely.
+Long-term dependencies SHOULD NOT be taken against experimental sections.
+
 ### Feature freeze
 
 In addition to the statuses above, documents may be marked as `Feature-freeze`.

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -3,7 +3,7 @@
 **Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
 
 All GDI repositories MUST be versioned according to [Semantic Versioning
-2.0](https://semver.org/spec/v2.0.0.html) and versioning idiomatic to their
+2.0](https://semver.org/spec/v2.0.0.html) using the syntax idiomatic to their
 language.
 GDI repositories are versioned separately from OpenTelemetry repositories as
 Splunk-specific breaking changes MAY be introduced.

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -5,6 +5,7 @@
 All GDI repositories MUST be versioned according to [Semantic Versioning
 2.0](https://semver.org/spec/v2.0.0.html) using the syntax idiomatic to their
 language.
+
 GDI repositories are versioned separately from OpenTelemetry repositories as
 Splunk-specific breaking changes MAY be introduced.
 GDI repositories MUST indicate what version of OpenTelemetry
@@ -32,9 +33,8 @@ configuration variable to enable, and MUST clearly be marked as experimental.
 
 ## Stable
 
-The initial stable release version number for GDI repositories MUST be `1.0.0` and
-follow Semantic Versioning 2.0 for all subsequent releases. Once an
-experimental component has gone through rigorous beta testing, it MAY
+The initial stable release version number for GDI repositories MUST be `1.0.0`.
+Once an experimental component has gone through rigorous beta testing, it MAY
 transition to stable. Long-term dependencies MAY now be taken against this
 component. When a new stable component is introduced to a GDI repository with an
 existing stable release, the `MINOR` version number MUST be incremented and the

--- a/specification/versioning.md
+++ b/specification/versioning.md
@@ -3,25 +3,16 @@
 **Status**: [Stable](../README.md#versioning-and-status-of-the-specification)
 
 All GDI repositories MUST be versioned according to [Semantic Versioning
-2.0](https://semver.org/spec/v2.0.0.html). GDI repositories are versioned
-separately from OpenTelemetry repositories as Splunk-specific breaking changes
-MAY be introduced. GDI repositories MUST indicate what version of OpenTelemetry
+2.0](https://semver.org/spec/v2.0.0.html) and versioning idiomatic to their
+language.
+GDI repositories are versioned separately from OpenTelemetry repositories as
+Splunk-specific breaking changes MAY be introduced.
+GDI repositories MUST indicate what version of OpenTelemetry
 repositories they are based on through release notes and SHOULD indicate through
 logging. Additional version number constraints can be found in the sections
 below.
 
 ## Experimental
-
-Everything in the specification starts as experimental, which covers alpha,
-beta, and release candidate versions. Version numbers for releases MUST be less
-than `1.0.0` while experimental. The minor version number SHOULD be increased
-when significant or breaking changes are introduced.
-
-While any section in the specification is experimental, breaking changes and
-performance issues MAY occur. Sections SHOULD NOT be expected to be
-feature-complete. In some cases, the experiment MAY be discarded and removed
-entirely. Long-term dependencies SHOULD NOT be taken against experimental
-sections.
 
 GDI repositories MAY consist of one or more components. GDI repositories MUST be
 designed in a manner that allows experimental components to be created without


### PR DESCRIPTION
Call out that the versioning the GDI components should by also idiomatic to their language; examples:
- Python: https://packaging.python.org/en/latest/discussions/versioning/ (e.g. in SemVer it should be `v1.2.0-rc.1` and not `1.2.0rc1`)
- Go: https://go.dev/doc/modules/version-numbers (`v` prefix is not really SemVer compliant)

`README.md` defines the GDI **specification** versioning and status.

`VERSIONING.md` defines GDI **component** versioning requirements.

Fixes https://github.com/signalfx/gdi-specification/issues/327