### PR TITLE
Define `profiling.instrumentation.source` Log Message Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Semantic Conventions
+
+#### Enhancements
+
+- Define the `PROFILING_INSTRUMENTATION_SOURCE` attribute with valid values of `continuous` and `snapshot`
+
 ## [1.7.0] - 2025-01-07
 
 ### Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 #### Enhancements
 
-- Define the `PROFILING_INSTRUMENTATION_SOURCE` attribute with valid values of `continuous` and `snapshot`
+- Define the `profiling.instrumentation.source` attribute with valid values of `continuous` and `snapshot`.
+[#336](https://github.com/signalfx/gdi-specification/pull/336)
 
 ## [1.7.0] - 2025-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 #### Enhancements
 
-- Define the `profiling.instrumentation.source` attribute with valid values of `continuous` and `snapshot`.
+- Define the `profiling.instrumentation.source` attribute with valid values
+  of `continuous` and `snapshot`.
 [#336](https://github.com/signalfx/gdi-specification/pull/336)
 
 ## [1.7.0] - 2025-01-07

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -129,7 +129,10 @@ instances. For each `LogRecord` instance:
   - `pprof-gzip-base64`,
   - `text` ([Deprecated](../README.md#versioning-and-status-of-the-specification)
     format).
-- `profiling.instrumentation.source` MUST be set to either `continuous` or `snapshot`
+- `profiling.instrumentation.source` MUST be set to either `continuous` or `snapshot` to 
+  identify the profiling mechanism reporting the callstacks
+  - `continuous` SHOULD be used to indicate the continuous "Always On" profiling
+  - `snapshot` SHOULD be used to indicate the trace snapshot profiling
 
 #### `LogRecord` Message `text` Data Format Specific Attributes
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -129,6 +129,7 @@ instances. For each `LogRecord` instance:
   - `pprof-gzip-base64`,
   - `text` ([Deprecated](../README.md#versioning-and-status-of-the-specification)
     format).
+- `profiling.instrumentation.source` MUST be set to either `continuous` or `snapshot`
 
 #### `LogRecord` Message `text` Data Format Specific Attributes
 

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -129,10 +129,9 @@ instances. For each `LogRecord` instance:
   - `pprof-gzip-base64`,
   - `text` ([Deprecated](../README.md#versioning-and-status-of-the-specification)
     format).
-- `profiling.instrumentation.source` MUST be set to either `continuous` or `snapshot` to 
-  identify the profiling mechanism reporting the callstacks
-  - `continuous` SHOULD be used to indicate the continuous "Always On" profiling
-  - `snapshot` SHOULD be used to indicate the trace snapshot profiling
+- `profiling.instrumentation.source` MUST be set to either:
+  - `continuous` for continuous "Always On" profiling
+  - `snapshot` for trace snapshot profiling
 
 #### `LogRecord` Message `text` Data Format Specific Attributes
 


### PR DESCRIPTION
The profiling backend ingestion process needs to be able to distinguish between callstacks collected by the existing continuous "Always On" profiler and those collected by the upcoming trace snapshot profiler. This PR defines an attribute to be included in a log message body that will identify which profiling process was responsible for collecting and reporting the exported callstacks.