### PR TITLE
Define profiling.instrumentation.source Log Message Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Semantic Conventions
+
+#### Enhancements
+
+- Define the `profiling.instrumentation.source` attribute with valid values
+  of `continuous` and `snapshot`.
+  [#336](https://github.com/signalfx/gdi-specification/pull/336)
+
 ## [1.7.0] - 2025-01-07
 
 ### Configuration

--- a/specification/semantic_conventions.md
+++ b/specification/semantic_conventions.md
@@ -129,6 +129,9 @@ instances. For each `LogRecord` instance:
   - `pprof-gzip-base64`,
   - `text` ([Deprecated](../README.md#versioning-and-status-of-the-specification)
     format).
+- `profiling.instrumentation.source` MUST be set to either:
+  - `continuous` for continuous "Always On" profiling
+  - `snapshot` for trace snapshot profiling
 
 #### `LogRecord` Message `text` Data Format Specific Attributes
 


### PR DESCRIPTION
The profiling backend ingestion process needs to be able to distinguish between callstacks collected by the existing continuous "Always On" profiler and those collected by the upcoming trace snapshot profiler. This PR defines an attribute to be included in a log message body that will identify which profiling process was responsible for collecting and reporting the exported callstacks.

See #336 for previous discussion.