### PR TITLE
AppD context -- First span is all we need.

### DIFF
--- a/specification/integration_context.md
+++ b/specification/integration_context.md
@@ -61,7 +61,7 @@ secret information in these fields, you should not use this feature.
 
 When `cisco.ctx.enabled` configuration is `true`, Splunk implementations MUST
 extract fields from the `cisco-ctx-*` headers (above) and add extra
-attributes to any Spans created as part of the incoming request context.
+attributes to the first Span created as part of the incoming request context.
 Null or missing values MUST be handled gracefully by simply
 omitting the span attributes.
 


### PR DESCRIPTION
Several people have brought up the point that putting the extra attributes on ALL spans with in a process shouldn't be necessary to paint the service map. Just the first one should suffice...so I'm hearing that feedback and applying it in this PR.