### PR TITLE
Clarify that deployments should live in each repo in a subdir of `deployments`

### DIFF
--- a/specification/repository.md
+++ b/specification/repository.md
@@ -191,6 +191,20 @@ to the repo.
   - SHOULD define maximum supported version of each auto-instrumentation framework
 - MAY host the documentation in the [Observability Cloud documentation repository](https://github.com/splunk/public-o11y-docs)
 
+## Deployments
+
+For this section, "deployments" refers to software tools, utilities, and/or configuration
+for packaging, distributing, and/or installing `splunk-otel` GDI software. Typically, these are 
+3rd-party frameworks like ansible, puppet, chef, cloudfoundry, etc. 
+The `splunk-otel-collector` [distributions](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments)
+are a good example of this.
+
+- Splunk O11y GDI repos MAY include one or more distributions
+- The distributions for a given GDI project MUST each exist within a separate subdirectory of a 
+  repo root directory named `distributions`.
+- An historical exemption is provided for `splunk-otel-collector-chart`, which MAY live in a
+  separate repository.
+
 ## Real User Monitoring Libraries
 
 - MUST document all configuration parameters that are relevant


### PR DESCRIPTION
As we build out ansible playbooks and other similar deployments, we should be clear that these stay with each repo, and we structure the repo dirs consistently across projects.