### PR TITLE
OpAMP configuration for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Configuration
 
-- Add initial configuration for OpAMP clients. 
-  [#375](https://github.com/signalfx/gdi-specification/pull/375) 
+- Add initial configuration for OpAMP clients.
+  [#375](https://github.com/signalfx/gdi-specification/pull/375)
 
 #### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Configuration
 
+- Add initial configuration for OpAMP clients. 
+  [#375](https://github.com/signalfx/gdi-specification/pull/375) 
+
 #### Breaking changes
 
 #### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@
 - Add initial configuration for OpAMP clients.
   [#375](https://github.com/signalfx/gdi-specification/pull/375)
 
-- Change ingestion URL templates by replacing `signalfx.com`
-  endpoints with `observability.splunkcloud.com`.
-  [#378](https://github.com/signalfx/gdi-specification/pull/378)
-
 #### Bugfixes
 
 ### Repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ### Configuration
 
-- Add initial configuration for OpAMP clients.
-  [#375](https://github.com/signalfx/gdi-specification/pull/375)
-
 #### Breaking changes
 
 #### Enhancements
+
+- Add initial configuration for OpAMP clients.
+  [#375](https://github.com/signalfx/gdi-specification/pull/375)
+
+- Change ingestion URL templates by replacing `signalfx.com`
+  endpoints with `observability.splunkcloud.com`.
+  [#378](https://github.com/signalfx/gdi-specification/pull/378)
 
 #### Bugfixes
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -367,8 +367,8 @@ distribution:
       polling_interval: 12
 ```
 
-_Note: When the opamp endpoint node is present in the yaml, it implies that the feature should
-be enabled._
+_Note: When the opamp endpoint node is present in the yaml, it implies that
+the feature should be enabled._
 
 ### Serverless
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -346,7 +346,7 @@ MUST be provided when opting in to OpAMP:
 | Name                    | Default | Description                                              |
 |-------------------------|---------|----------------------------------------------------------|
 | `SPLUNK_OPAMP_ENABLED`  | false   | Set to `true` to opt into connecting to an OpAMP server. |
-| `SPLUNK_OPAMP_ENDPOINT` | <none>  | The URL endpoint of the OpAMP server to use.             |
+| `SPLUNK_OPAMP_ENDPOINT` | (none)  | The URL endpoint of the OpAMP server to use.             |
 
 The following optional configuration options MAY be provided:
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -343,7 +343,6 @@ enabled by default.
 When using environment-variable based agent configuration, the following MUST be provided
 when opting in to OpAMP:
 
-
 | Name                    | Default | Description                                              |
 |-------------------------|---------|----------------------------------------------------------|
 | `SPLUNK_OPAMP_ENABLED`  | false   | Set to `true` to opt into connecting to an OpAMP server. |
@@ -355,8 +354,18 @@ The following optional configuration options MAY be provided:
 |---------------------------------|---------|--------------------------------------------------|
 | `SPLUNK_OPAMP_POLLING_INTERVAL` | 30      | Number of seconds between agent-to-server polls. |
 
-
 #### OpAMP declarative yaml
+
+If a declarative yaml file is used to configure the agent, the OpAMP config looks like this:
+
+```yaml
+distribution:
+  splunk:
+    opamp:
+      enabled: true
+      endpoint: http://some.opamp-host.com:7777/v1/opamp
+      polling_interval: 12
+```
 
 ### Serverless
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -350,9 +350,9 @@ MUST be provided when opting in to OpAMP:
 
 The following optional configuration options MAY be provided:
 
-| Name                            | Default | Description                                      |
-|---------------------------------|---------|--------------------------------------------------|
-| `SPLUNK_OPAMP_POLLING_INTERVAL` | 30      | Number of seconds between agent-to-server polls. |
+| Name                            | Default | Description                                           |
+|---------------------------------|---------|-------------------------------------------------------|
+| `SPLUNK_OPAMP_POLLING_INTERVAL` | 30000   | Number of milliseconds between agent-to-server polls. |
 
 #### OpAMP declarative yaml
 
@@ -363,10 +363,12 @@ looks like this:
 distribution:
   splunk:
     opamp:
-      enabled: true
       endpoint: http://some.opamp-host.com:7777/v1/opamp
       polling_interval: 12
 ```
+
+_Note: When the opamp endpoint node is present in the yaml, it implies that the feature should
+be enabled._
 
 ### Serverless
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -335,13 +335,13 @@ variable configurations MUST be available:
 
 ### OpAMP
 
-Agents MAY include the ability to connect to an OpAMP server. This feature MUST be opt-in and not 
-enabled by default. 
+Agents MAY include the ability to connect to an OpAMP server. This feature
+MUST be opt-in and not enabled by default.
 
 #### OpAMP environment
 
-When using environment-variable based agent configuration, the following MUST be provided
-when opting in to OpAMP:
+When using environment-variable based agent configuration, the following
+MUST be provided when opting in to OpAMP:
 
 | Name                    | Default | Description                                              |
 |-------------------------|---------|----------------------------------------------------------|
@@ -356,7 +356,8 @@ The following optional configuration options MAY be provided:
 
 #### OpAMP declarative yaml
 
-If a declarative yaml file is used to configure the agent, the OpAMP config looks like this:
+If a declarative yaml file is used to configure the agent, the OpAMP config
+looks like this:
 
 ```yaml
 distribution:

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -333,6 +333,31 @@ variable configurations MUST be available:
   - Java: 10ms
   - Node.js: 1ms
 
+### OpAMP
+
+Agents MAY include the ability to connect to an OpAMP server. This feature MUST be opt-in and not 
+enabled by default. 
+
+#### OpAMP environment
+
+When using environment-variable based agent configuration, the following MUST be provided
+when opting in to OpAMP:
+
+
+| Name                    | Default | Description                                              |
+|-------------------------|---------|----------------------------------------------------------|
+| `SPLUNK_OPAMP_ENABLED`  | false   | Set to `true` to opt into connecting to an OpAMP server. |
+| `SPLUNK_OPAMP_ENDPOINT` | <none>  | The URL endpoint of the OpAMP server to use.             |
+
+The following optional configuration options MAY be provided:
+
+| Name                            | Default | Description                                      |
+|---------------------------------|---------|--------------------------------------------------|
+| `SPLUNK_OPAMP_POLLING_INTERVAL` | 30      | Number of seconds between agent-to-server polls. |
+
+
+#### OpAMP declarative yaml
+
 ### Serverless
 
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -365,7 +365,7 @@ looks like this:
 distribution:
   splunk:
     opamp:
-      endpoint: http://some.opamp-host.com:7777/v1/opamp
+      endpoint: http://some.opamp-host.com:3420/v1/opamp
       polling_interval: 12
 ```
 

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -364,7 +364,7 @@ looks like this:
 ```yaml
 distribution:
   splunk:
-    opamp:
+    opamp:/development
       endpoint: http://some.opamp-host.com:3420/v1/opamp
       polling_interval: 12
 ```

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -335,6 +335,8 @@ variable configurations MUST be available:
 
 ### OpAMP
 
+**Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
+
 Agents MAY include the ability to connect to an OpAMP server. This feature
 MUST be opt-in and not enabled by default.
 


### PR DESCRIPTION
This allows us to align configuration for agents that support OpAMP.

* opt-in / enable
* url to connect to
* (optional) polling interval