### PR TITLE
Introduce opamp data model for agents, starting with identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 #### Bugfixes
 
+### OpAMP Data Model
+
+#### Enhancements
+
+- Add initial data model for agent identify with OpAMP.
+  [#379](https://github.com/signalfx/gdi-specification/pull/379)
+
 ## [1.9.0] - 2026-04-07
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following specification sections are currently in scope:
 - [Semantic Conventions](specification/semantic_conventions.md)
 - [Repository](specification/repository.md)
 - [Versioning](specification/versioning.md)
+- [OpAMP Data Model](specification/opamp_datamodel.md)
 
 GDI repositories MUST adopt GDI specification changes by their next `MINOR` release
 and within three months (whichever is sooner). The GDI specification and GDI

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -8,7 +8,7 @@ an OpAMP server. For more information about OpAMP, please see the
 
 ## Identifying Attributes
 
-The `AgentDescription` message includes a set of 
+The `AgentDescription` message includes a set of
 [identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes).
 Agents MUST copy these attributes from the OpenTelemetry resource and
 MUST use existing semantic conventions when they exist. Any attribute

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -1,0 +1,42 @@
+# OpAMP Data Model
+
+**Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
+
+This document describes agent data model fields when configured to speak with
+an OpAMP server. For more information about OpAMP, please see the
+[opamp-spec](https://github.com/open-telemetry/opamp-spec).
+
+## Identifying Attributes
+
+The `AgentDescription` message includes a set of 
+[identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes).
+Agents MUST copy these attributes from the OpenTelemetry resource and
+MUST use existing semantic conventions when they exist. Any attribute
+that is not available MUST be omitted. The list of identifying attributes
+SHOULD include the following, as available:
+
+* [deployment.environment.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-environment-name)
+* [service.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name)
+* [service.namespace](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-namespace)
+* [service.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-version)
+* [service.instance.id](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id)
+
+## Non-Identifying Attributes
+
+The `AgentDescription` message includes a set of
+[non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes).
+Agents MUST copy these attributes from the OpenTelemetry resource and
+MUST use existing semantic conventions when they exist. Any attribute
+that is not available MUST be omitted. The list of non-identifying attributes
+SHOULD include the following, as available:
+
+* [os.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-name)
+* [os.type](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-type)
+* [os.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-version)
+* [host.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/#host-name)
+* [telemetry.distro.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-distro-name)
+* [telemetry.distro.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-distro-version)
+* [k8s.cluster.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-cluster-name)
+* [k8s.namespace.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-namespace-name)
+* [k8s.node.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-node-name)
+* [k8s.pod.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-pod-name)

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -2,8 +2,9 @@
 
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
 
-This document describes agent data model fields when configured to speak with
-an OpAMP server. For more information about OpAMP, please see the
+This document describes data model fields used by *language agents*
+when configured to communicate with an OpAMP server. For more information
+about OpAMP, please see the
 [opamp-spec](https://github.com/open-telemetry/opamp-spec).
 
 ## Identifying Attributes

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -10,33 +10,15 @@ an OpAMP server. For more information about OpAMP, please see the
 
 The `AgentDescription` message includes a set of
 [identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes).
-Agents MUST copy these attributes from the OpenTelemetry resource and
-MUST use existing semantic conventions when they exist. Any attribute
-that is not available MUST be omitted. The list of identifying attributes
-SHOULD include the following, as available:
 
-* [deployment.environment.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-environment-name)
-* [service.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name)
-* [service.namespace](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-namespace)
-* [service.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-version)
-* [service.instance.id](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id)
+This set of identifying attributes MUST be comprised, in its entirety,
+of the Agent's resource attributes. All detected or configured
+resource attributes MUST be present in the identifying attributes.
+The identifying attributes MUST NOT contain any other attributes
+that are not obtained from the current Resource.
 
 ## Non-Identifying Attributes
 
 The `AgentDescription` message includes a set of
 [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes).
-Agents MUST copy these attributes from the OpenTelemetry resource and
-MUST use existing semantic conventions when they exist. Any attribute
-that is not available MUST be omitted. The list of non-identifying attributes
-SHOULD include the following, as available:
-
-* [os.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-name)
-* [os.type](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-type)
-* [os.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/#os-version)
-* [host.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/#host-name)
-* [telemetry.distro.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-distro-name)
-* [telemetry.distro.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-distro-version)
-* [k8s.cluster.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-cluster-name)
-* [k8s.namespace.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-namespace-name)
-* [k8s.node.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-node-name)
-* [k8s.pod.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/#k8s-pod-name)
+Agents SHOULD NOT specify any non-identifying attributes.


### PR DESCRIPTION
We need to flesh out some common data model for agents that wish to speak opamp to a server. This is the start of that. It is based on the upstream opamp spec and some additional requirements from the agent management team.

We will be following this up with additional data model and formats, like around reporting and receiving config.