### PR TITLE
Remove splunk-otel-ruby from repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -10,4 +10,3 @@ https://github.com/signalfx/splunk-otel-js
 https://github.com/signalfx/splunk-otel-lambda
 https://github.com/signalfx/splunk-otel-python
 https://github.com/signalfx/splunk-otel-react-native
-https://github.com/signalfx/splunk-otel-ruby


### PR DESCRIPTION
Found while working on v1.9.0 release. Repository is now marked as public archived.
There is no possibility to create issues there/update it.