### PR TITLE
Require use of GHA hash instead of version tag/string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 #### Enhancements
 
+- Require referencing GitHub Actions by commit hash.
+  [#385](https://github.com/signalfx/gdi-specification/pull/385)
+
 #### Bugfixes
 
 ### Repository

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -82,6 +82,7 @@ to the repo.
   [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets)
   to store sensitive data (auth tokens, passwords) and limit their usage to
   only required places
+- MUST only reference GitHub Actions by commit hash and never by version tag/string.
 - MUST NOT use [Personal Access
   Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 - MUST [limit permissions of


### PR DESCRIPTION
GHA version tags/strings are immutable. This is very problematic and leaves opportunity for attackers to retroactively modify existing usages of actions.

I will not be able to make all these changes myself, but it is pretty straightforward to automate using contemporary tooling. Some examples:

* https://github.com/signalfx/splunk-otel-js/pull/1106
* https://github.com/signalfx/splunk-otel-java/pull/2740