### PR TITLE
Remove splunk-otel-react-native from repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9,4 +9,3 @@ https://github.com/signalfx/splunk-otel-java
 https://github.com/signalfx/splunk-otel-js
 https://github.com/signalfx/splunk-otel-lambda
 https://github.com/signalfx/splunk-otel-python
-https://github.com/signalfx/splunk-otel-react-native


### PR DESCRIPTION
Since RUM agents are no longer under GDI, this repository appears to be a leftover from a previous removal of the RUM Agents: https://github.com/signalfx/gdi-specification/pull/344