### PR TITLE
Align OpAMP data model guidance with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 #### Enhancements
 
+- Align OpAMP data model guidance with upstream `opamp-spec`.
 - Add initial data model for agent identify with OpAMP.
   [#379](https://github.com/signalfx/gdi-specification/pull/379)
 

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -3,23 +3,23 @@
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
 
 This document describes data model fields used by *language agents*
-when configured to communicate with an OpAMP server. For more information
-about OpAMP, please see the
-[opamp-spec](https://github.com/open-telemetry/opamp-spec).
+when configured to communicate with an OpAMP server.
+
+Guidance for OpenTelemetry language agents is defined upstream in
+[OpenTelemetry Guidelines](https://github.com/open-telemetry/opamp-spec/blob/main/opentelemetry-guidelines.md)
+in the [opamp-spec](https://github.com/open-telemetry/opamp-spec).
+GDI language agents that use OpAMP SHOULD follow that upstream guidance.
 
 ## Identifying Attributes
 
 The `AgentDescription` message includes a set of
 [identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes).
-
-This set of identifying attributes MUST be comprised, in its entirety,
-of the Agent's resource attributes. All detected or configured
-resource attributes MUST be present in the identifying attributes.
-The identifying attributes MUST NOT contain any other attributes
-that are not obtained from the current Resource.
+GDI language agents SHOULD follow the upstream guidance for which
+OpenTelemetry `Resource` attributes belong in this field.
 
 ## Non-Identifying Attributes
 
 The `AgentDescription` message includes a set of
 [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes).
-Agents SHOULD NOT specify any non-identifying attributes.
+GDI language agents SHOULD follow the upstream guidance for which
+OpenTelemetry `Resource` attributes belong in this field.


### PR DESCRIPTION
This aligns this repo with open-telemetry/opamp-spec#312 and removes the contradictory guidance added in #379.