### PR TITLE
Update declarative config env var name

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -256,7 +256,8 @@ In addition to environment variables, other ways of defining configuration exist
 
 OpenTelemetry's [declarative configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/README.md#declarative-configuration)
 SHOULD be supported via [`OTEL_CONFIG_FILE`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#declarative-configuration)
-environment variable. For backwards compatibility, agents MAY fall back to the deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` variable.
+environment variable. For backwards compatibility, agents MAY fall back to the deprecated
+`OTEL_EXPERIMENTAL_CONFIG_FILE` variable.
 
 In addition, Splunk specific configuration MUST have their own root-level
 configuration block named `splunk`.

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -255,7 +255,7 @@ In addition to environment variables, other ways of defining configuration exist
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
 
 OpenTelemetry's [declarative configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/README.md#declarative-configuration)
-SHOULD be supported via [`OTEL_CONFIG_FILE`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk.md#via-otel_experimental_config_file)
+SHOULD be supported via [`OTEL_CONFIG_FILE`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#declarative-configuration)
 environment variable. For backwards compatibility, agents MAY fall back to the deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` variable.
 
 In addition, Splunk specific configuration MUST have their own root-level

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -255,8 +255,8 @@ In addition to environment variables, other ways of defining configuration exist
 **Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
 
 OpenTelemetry's [declarative configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/README.md#declarative-configuration)
-SHOULD be supported via [`OTEL_EXPERIMENTAL_CONFIG_FILE`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk.md#via-otel_experimental_config_file)
-environment variable.
+SHOULD be supported via [`OTEL_CONFIG_FILE`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk.md#via-otel_experimental_config_file)
+environment variable. For backwards compatibility, agents MAY fall back to the deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` variable.
 
 In addition, Splunk specific configuration MUST have their own root-level
 configuration block named `splunk`.


### PR DESCRIPTION
The old experimental var is deprecated. Let's update to match.