### PR TITLE
Start adding spec for remote config

### DIFF
--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -366,10 +366,11 @@ looks like this:
 ```yaml
 distribution:
   splunk:
-    opamp:/development
+    opamp/development:
       endpoint: http://some.opamp-host.com:3420/v1/opamp
       polling_interval: 30000
-      remote_config: true
+      features:
+        remote_config:
 ```
 
 _Note: When the opamp endpoint node is present in the yaml, it implies that

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -346,16 +346,17 @@ MUST be opt-in and not enabled by default.
 When using environment-variable based agent configuration, the following
 MUST be provided when opting in to OpAMP:
 
-| Name                    | Default | Description                                              |
-|-------------------------|---------|----------------------------------------------------------|
-| `SPLUNK_OPAMP_ENABLED`  | false   | Set to `true` to opt into connecting to an OpAMP server. |
-| `SPLUNK_OPAMP_ENDPOINT` | (none)  | The URL endpoint of the OpAMP server to use.             |
+| Name                         | Default | Description                                              |
+|------------------------------|---------|----------------------------------------------------------|
+| `SPLUNK_OPAMP_ENABLED`       | false   | Set to `true` to opt into connecting to an OpAMP server. |
+| `SPLUNK_OPAMP_ENDPOINT`      | (none)  | The URL endpoint of the OpAMP server to use.             |
 
 The following optional configuration options MAY be provided:
 
-| Name                            | Default | Description                                           |
-|---------------------------------|---------|-------------------------------------------------------|
-| `SPLUNK_OPAMP_POLLING_INTERVAL` | 30000   | Number of milliseconds between agent-to-server polls. |
+| Name                            | Default | Description                                            |
+|---------------------------------|---------|--------------------------------------------------------|
+| `SPLUNK_OPAMP_POLLING_INTERVAL` | 30000   | Number of milliseconds between agent-to-server polls.  |
+| `SPLUNK_OPAMP_REMOTE_CONFIG`    | false   | Set to `true` to enable remote configuration features. |
 
 #### OpAMP declarative yaml
 
@@ -368,6 +369,7 @@ distribution:
     opamp:/development
       endpoint: http://some.opamp-host.com:3420/v1/opamp
       polling_interval: 30000
+      remote_config: true
 ```
 
 _Note: When the opamp endpoint node is present in the yaml, it implies that

--- a/specification/configuration.md
+++ b/specification/configuration.md
@@ -346,10 +346,10 @@ MUST be opt-in and not enabled by default.
 When using environment-variable based agent configuration, the following
 MUST be provided when opting in to OpAMP:
 
-| Name                         | Default | Description                                              |
-|------------------------------|---------|----------------------------------------------------------|
-| `SPLUNK_OPAMP_ENABLED`       | false   | Set to `true` to opt into connecting to an OpAMP server. |
-| `SPLUNK_OPAMP_ENDPOINT`      | (none)  | The URL endpoint of the OpAMP server to use.             |
+| Name                    | Default | Description                                              |
+|-------------------------|---------|----------------------------------------------------------|
+| `SPLUNK_OPAMP_ENABLED`  | false   | Set to `true` to opt into connecting to an OpAMP server. |
+| `SPLUNK_OPAMP_ENDPOINT` | (none)  | The URL endpoint of the OpAMP server to use.             |
 
 The following optional configuration options MAY be provided:
 

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -276,3 +276,19 @@ feature is not active.
 
 Note: The true configuration file may be significantly larger or more
 complicated than what is actually provided via effective configuration.
+
+## Remote Configuration
+
+Some agents will be able to accept remote configuration in order to modify
+their behavior at runtime. This is an opt-in feature.
+
+Agents that can accept remote configuration to dynamically modify runtime
+behavior, MUST accept payloads from the 
+[`AgentRemoteConfig.AgentConfigMap`](https://opentelemetry.io/docs/specs/opamp/#agentremoteconfig-message)
+with the key `splunk.remote.config`.
+
+Agents MAY accept payloads from other `AgentRemoteConfig.AgentConfigMap` keys not defined in 
+this specification. 
+
+* The specific format of this configuration is TBD.
+* The specific configuration settings inside this configuration are TBD.

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -279,6 +279,8 @@ complicated than what is actually provided via effective configuration.
 
 ## Remote Configuration
 
+**Status**: [Experimental](../README.md#versioning-and-status-of-the-specification)
+
 Some agents will be able to accept remote configuration in order to modify
 their behavior at runtime. This is an opt-in feature.
 

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -283,12 +283,12 @@ Some agents will be able to accept remote configuration in order to modify
 their behavior at runtime. This is an opt-in feature.
 
 Agents that can accept remote configuration to dynamically modify runtime
-behavior, MUST accept payloads from the 
+behavior, MUST accept payloads from the
 [`AgentRemoteConfig.AgentConfigMap`](https://opentelemetry.io/docs/specs/opamp/#agentremoteconfig-message)
 with the key `splunk.remote.config`.
 
-Agents MAY accept payloads from other `AgentRemoteConfig.AgentConfigMap` keys not defined in 
-this specification. 
+Agents MAY accept payloads from other `AgentRemoteConfig.AgentConfigMap` keys
+not defined in this specification.
 
 * The specific format of this configuration is TBD.
 * The specific configuration settings inside this configuration are TBD.


### PR DESCRIPTION
Taking some small baby steps around remote configuration. Trying to do this very incrementally. This is experimental.

This PR:

* Adds an opt-in config item for remote configuration.
* Specs the key name that agents should care about from the remote config map.

What it intentionally does not do, that I expect will need consideration in following PRs:

* content type of the file
* format details of the file
* required/optional config items
* behavioral/operational concerns