### PR TITLE
[RemoteConfig] Add empty `config_map` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@
 - Add support for remote config.
   [#396](https://github.com/signalfx/gdi-specification/pull/396),
   [#402](https://github.com/signalfx/gdi-specification/pull/402),
-  [#406](https://github.com/signalfx/gdi-specification/pull/406)
+  [#406](https://github.com/signalfx/gdi-specification/pull/406),
+  [#410](https://github.com/signalfx/gdi-specification/pull/410)
 - Add support for callgraph selection probability
   in the effective configuration.
   [#409](https://github.com/signalfx/gdi-specification/pull/409)

--- a/specification/opamp_datamodel.md
+++ b/specification/opamp_datamodel.md
@@ -306,6 +306,14 @@ remote configuration. After that, the accepted remote configuration is the
 authoritative source for whether profilers are running and for the profiler
 settings it contains.
 
+An `AgentRemoteConfig` is completely empty when its `config.config_map`
+contains no entries. When an agent receives a completely empty remote
+configuration, it MUST discard any previously accepted remote configuration
+and restore all profiling settings represented by this schema to the values
+from the initial agent configuration established at startup. The initial agent
+configuration remains authoritative until the agent accepts another non-empty
+remote configuration.
+
 ### Data Format
 
 When agents receive a remote configuration with the key `splunk.remote.config` and


### PR DESCRIPTION
## Why

https://github.com/signalfx/gdi-specification/pull/406#discussion_r3691211815

Currently, we don't have the possibility to fall back to the startup values, so I think one option could be to treat an empty config map as a signal to use the initial agent configuration.